### PR TITLE
Added scroll polyfill to support older browsers.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14506,6 +14506,11 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "rxjs": "^6.3.3",
+    "smoothscroll-polyfill": "^0.4.4",
     "whatwg-fetch": "3.0.0"
   },
   "sassIncludes": {

--- a/src/App.js
+++ b/src/App.js
@@ -10,9 +10,12 @@ import { MIN_SCREEN_HEIGHT } from './constants/ui-constants';
 import { AppPlaceholder } from './PresentationalComponents/Shared/LoaderPlaceholders';
 
 import 'whatwg-fetch';
+import smoothscroll from 'smoothscroll-polyfill';
 
 import '@red-hat-insights/insights-frontend-components/components/Notifications.css';
 import './App.scss';
+
+smoothscroll.polyfill();
 
 class App extends Component {
   state = {


### PR DESCRIPTION
Should fix an issue with older browsers that does not support `scroll` methods on Element prototype.