### PR TITLE
Fixed pagination alignment in platform items screen.

### DIFF
--- a/src/presentational-components/platform/platform-toolbar.js
+++ b/src/presentational-components/platform/platform-toolbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Level, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Level, LevelItem } from '@patternfly/react-core';
 import TopToolbar, { TopToolbarTitle } from '../shared/top-toolbar';
 import FilterToolbarItem from '../shared/filter-toolbar-item';
 
@@ -8,18 +8,12 @@ const PlatformToolbar = ({ searchValue, onFilterChange, title, children }) => (
   <TopToolbar>
     <TopToolbarTitle title={ title } />
     <Level>
-      <Toolbar>
-        <ToolbarGroup>
-          <ToolbarItem>
-            <FilterToolbarItem searchValue={ searchValue } onFilterChange={ onFilterChange } placeholder="Filter by name..." />
-          </ToolbarItem>
-        </ToolbarGroup>
-        <ToolbarGroup>
-          <ToolbarItem>
-            { children }
-          </ToolbarItem>
-        </ToolbarGroup>
-      </Toolbar>
+      <LevelItem>
+        <FilterToolbarItem searchValue={ searchValue } onFilterChange={ onFilterChange } placeholder="Filter by name..." />
+      </LevelItem>
+      <LevelItem>
+        { children }
+      </LevelItem>
     </Level>
   </TopToolbar>
 );

--- a/src/test/presentational-components/platform/__snapshots__/platform-toolbar.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-toolbar.test.js.snap
@@ -11,30 +11,14 @@ exports[`<PlatformToolbar /> should render correctly 1`] = `
     className=""
     gutter={null}
   >
-    <Toolbar
-      className={null}
-    >
-      <ToolbarGroup
-        className={null}
-      >
-        <ToolbarItem
-          className={null}
-        >
-          <FilterToolbarItem
-            onFilterChange={[MockFunction]}
-            placeholder="Filter by name..."
-            searchValue=""
-          />
-        </ToolbarItem>
-      </ToolbarGroup>
-      <ToolbarGroup
-        className={null}
-      >
-        <ToolbarItem
-          className={null}
-        />
-      </ToolbarGroup>
-    </Toolbar>
+    <LevelItem>
+      <FilterToolbarItem
+        onFilterChange={[MockFunction]}
+        placeholder="Filter by name..."
+        searchValue=""
+      />
+    </LevelItem>
+    <LevelItem />
   </Level>
 </TopToolbar>
 `;


### PR DESCRIPTION
### Changes
- moved pagination bar on platform items screen to the right to match PF guidelines.

![screenshot-ci foo redhat com-1337-2019 03 28-14-55-41](https://user-images.githubusercontent.com/22619452/55163173-971a2600-5169-11e9-94e4-0ff14f04bf75.png)
