### PR TITLE
Removed breadcrumbs with only one level.

### DIFF
--- a/src/presentational-components/shared/breadcrubms.js
+++ b/src/presentational-components/shared/breadcrubms.js
@@ -96,8 +96,8 @@ const CatalogBreadrubms = ({ match: { url }, reducers }) => {
     </BreadcrumbItem>
   ));
   return (
-    <Breadcrumb>
-      { items }
+    <Breadcrumb style={ { minHeight: 18 } }>
+      { items.length > 1 && items }
     </Breadcrumb>
   );
 };


### PR DESCRIPTION
Removes breadcrumbs from first level pages to match mocks. Now will only show there there are two or more levels of nesting. 

Affected routes
- /portfolios
- /platforms
- /orders