### PR TITLE
Fix card line clamping in Firefox.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7074,14 +7074,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7096,20 +7094,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7226,8 +7221,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7239,7 +7233,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7254,7 +7247,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7262,14 +7254,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7288,7 +7278,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7369,8 +7358,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7382,7 +7370,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7504,7 +7491,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11431,7 +11417,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -11439,8 +11424,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -13159,6 +13143,14 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.3"
+      }
+    },
+    "react-dotdotdot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/react-dotdotdot/-/react-dotdotdot-1.2.3.tgz",
+      "integrity": "sha512-lYCHCegi76+kqmgqkii/ma2QqsfA1Slf5jTJYWKgnT3uz8EkPaO9hRDPMDEsDHEBua2qOXSxWCHxVf4N740W1w==",
+      "requires": {
+        "object.pick": "^1.3.0"
       }
     },
     "react-final-form": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^16.8.3",
     "react-content-loader": "^3.4.2",
     "react-dom": "^16.8.3",
+    "react-dotdotdot": "^1.2.3",
     "react-lazy-load-image-component": "^1.3.2",
     "react-select": "^2.1.2",
     "redux-logger": "^3.0.6",

--- a/src/presentational-components/shared/card-common.js
+++ b/src/presentational-components/shared/card-common.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Dotdotdot from 'react-dotdotdot';
 
 const PropLine = ({ value }) => <div>{ value }</div>;
 
@@ -15,9 +16,9 @@ PropLine.propTypes = {
 };
 
 const ItemDetails = ({ toDisplay = [], ...item }) => (
-  <div className="line-clamp">
+  <Dotdotdot clamp={ 6 }>
     { toDisplay.map(prop => <PropLine key={ `card-prop-${prop}` } value={ item[prop] } />) }
-  </div>
+  </Dotdotdot>
 );
 
 ItemDetails.propTypes = {

--- a/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
@@ -61,26 +61,31 @@ exports[`<PlatformCard /> should choose card image 1`] = `
                       ]
                     }
                   >
-                    <div
-                      className="line-clamp"
+                    <Dotdotdot
+                      clamp={6}
+                      tagName="div"
+                      truncationChar="…"
+                      useNativeClamp={true}
                     >
-                      <PropLine
-                        key="card-prop-description"
-                        value="desc"
-                      >
-                        <div>
-                          desc
-                        </div>
-                      </PropLine>
-                      <PropLine
-                        key="card-prop-modified"
-                        value="Foo"
-                      >
-                        <div>
-                          Foo
-                        </div>
-                      </PropLine>
-                    </div>
+                      <div>
+                        <PropLine
+                          key="card-prop-description"
+                          value="desc"
+                        >
+                          <div>
+                            desc
+                          </div>
+                        </PropLine>
+                        <PropLine
+                          key="card-prop-modified"
+                          value="Foo"
+                        >
+                          <div>
+                            Foo
+                          </div>
+                        </PropLine>
+                      </div>
+                    </Dotdotdot>
                   </ItemDetails>
                 </div>
               </CardBody>
@@ -162,26 +167,31 @@ exports[`<PlatformCard /> should render correctly 1`] = `
                       ]
                     }
                   >
-                    <div
-                      className="line-clamp"
+                    <Dotdotdot
+                      clamp={6}
+                      tagName="div"
+                      truncationChar="…"
+                      useNativeClamp={true}
                     >
-                      <PropLine
-                        key="card-prop-description"
-                        value="desc"
-                      >
-                        <div>
-                          desc
-                        </div>
-                      </PropLine>
-                      <PropLine
-                        key="card-prop-modified"
-                        value="Foo"
-                      >
-                        <div>
-                          Foo
-                        </div>
-                      </PropLine>
-                    </div>
+                      <div>
+                        <PropLine
+                          key="card-prop-description"
+                          value="desc"
+                        >
+                          <div>
+                            desc
+                          </div>
+                        </PropLine>
+                        <PropLine
+                          key="card-prop-modified"
+                          value="Foo"
+                        >
+                          <div>
+                            Foo
+                          </div>
+                        </PropLine>
+                      </div>
+                    </Dotdotdot>
                   </ItemDetails>
                 </div>
               </CardBody>

--- a/src/test/presentational-components/shared/__snapshots__/card-common.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/card-common.test.js.snap
@@ -4,9 +4,14 @@ exports[`<CardCommon /> should render correctly empty 1`] = `
 <ItemDetails
   toDisplay={Array []}
 >
-  <div
-    className="line-clamp"
-  />
+  <Dotdotdot
+    clamp={6}
+    tagName="div"
+    truncationChar="…"
+    useNativeClamp={true}
+  >
+    <div />
+  </Dotdotdot>
 </ItemDetails>
 `;
 
@@ -25,31 +30,36 @@ exports[`<CardCommon /> should render correctly with content 1`] = `
     ]
   }
 >
-  <div
-    className="line-clamp"
+  <Dotdotdot
+    clamp={6}
+    tagName="div"
+    truncationChar="…"
+    useNativeClamp={true}
   >
-    <PropLine
-      key="card-prop-foo"
-      value="Foo content"
-    >
-      <div>
-        Foo content
-      </div>
-    </PropLine>
-    <PropLine
-      key="card-prop-bar"
-      value={
-        <h1>
-          Bar content
-        </h1>
-      }
-    >
-      <div>
-        <h1>
-          Bar content
-        </h1>
-      </div>
-    </PropLine>
-  </div>
+    <div>
+      <PropLine
+        key="card-prop-foo"
+        value="Foo content"
+      >
+        <div>
+          Foo content
+        </div>
+      </PropLine>
+      <PropLine
+        key="card-prop-bar"
+        value={
+          <h1>
+            Bar content
+          </h1>
+        }
+      >
+        <div>
+          <h1>
+            Bar content
+          </h1>
+        </div>
+      </PropLine>
+    </div>
+  </Dotdotdot>
 </ItemDetails>
 `;

--- a/src/test/presentational-components/shared/__snapshots__/service-offering-body.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/service-offering-body.test.js.snap
@@ -65,18 +65,23 @@ exports[`<ServiceOfferingCardBody /> should render correctly 1`] = `
           ]
         }
       >
-        <div
-          className="line-clamp"
+        <Dotdotdot
+          clamp={6}
+          tagName="div"
+          truncationChar="…"
+          useNativeClamp={true}
         >
-          <PropLine
-            key="card-prop-long_description"
-            value="long description"
-          >
-            <div>
-              long description
-            </div>
-          </PropLine>
-        </div>
+          <div>
+            <PropLine
+              key="card-prop-long_description"
+              value="long description"
+            >
+              <div>
+                long description
+              </div>
+            </PropLine>
+          </div>
+        </Dotdotdot>
       </ItemDetails>
     </div>
   </CardBody>
@@ -145,18 +150,23 @@ exports[`<ServiceOfferingCardBody /> should render correctly with alternative va
           ]
         }
       >
-        <div
-          className="line-clamp"
+        <Dotdotdot
+          clamp={6}
+          tagName="div"
+          truncationChar="…"
+          useNativeClamp={true}
         >
-          <PropLine
-            key="card-prop-description"
-            value="Bar"
-          >
-            <div>
-              Bar
-            </div>
-          </PropLine>
-        </div>
+          <div>
+            <PropLine
+              key="card-prop-description"
+              value="Bar"
+            >
+              <div>
+                Bar
+              </div>
+            </PropLine>
+          </div>
+        </Dotdotdot>
       </ItemDetails>
     </div>
   </CardBody>


### PR DESCRIPTION
I've replaced the CSS with react component. Its not pretty but if we want multi line ellipsis effect there is no other way unfortunately. Firefox simply does not support `line-clamp` CSS property.

### Before
![Screenshot from 2019-04-10 14-39-22](https://user-images.githubusercontent.com/22619452/55879308-9a1c0a00-5b9e-11e9-9101-015133119a5b.png)

### After
![Screenshot from 2019-04-10 14-41-29](https://user-images.githubusercontent.com/22619452/55879384-ca63a880-5b9e-11e9-8a56-f73f8f49cbaa.png)
