### PR TITLE
Empty states for platforms portfolios and portfolio screens

### DIFF
--- a/src/presentational-components/shared/content-gallery-empty-state.js
+++ b/src/presentational-components/shared/content-gallery-empty-state.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Text,
+  TextContent,
+  TextVariants
+} from '@patternfly/react-core';
+
+const ContentGalleryEmptyState = ({
+  title,
+  Icon,
+  description,
+  PrimaryAction,
+  renderDescription
+}) => (
+  <Bullseye style={ { height: 'calc(100% - 197px)' } }>
+    <EmptyState>
+      <EmptyStateIcon icon={ Icon } />
+      <TextContent>
+        <Text component={ TextVariants.h1 }>
+          { title }
+        </Text>
+      </TextContent>
+      <EmptyStateBody>
+        { description }
+        { renderDescription() }
+      </EmptyStateBody>
+      <EmptyStateSecondaryActions>
+        { PrimaryAction && <PrimaryAction /> }
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  </Bullseye>
+);
+
+ContentGalleryEmptyState.defaultProps = {
+  renderDescription: () => null
+};
+
+ContentGalleryEmptyState.propTypes = {
+  title: PropTypes.string.isRequired,
+  Icon: PropTypes.any.isRequired,
+  description: PropTypes.string.isRequired,
+  PrimaryAction: PropTypes.any,
+  renderDescription: PropTypes.func
+};
+
+export default ContentGalleryEmptyState;
+
+export const EmptyStatePrimaryAction = ({ url, label }) => (
+  <Link to={ url }>
+    <Button variant="secondary">{ label }</Button>
+  </Link>
+);
+
+EmptyStatePrimaryAction.propTypes = {
+  url: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired
+};

--- a/src/smart-components/content-gallery/content-gallery.js
+++ b/src/smart-components/content-gallery/content-gallery.js
@@ -1,25 +1,34 @@
 import React from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { Section } from '@red-hat-insights/insights-frontend-components';
+import { Text, TextVariants, Gallery } from '@patternfly/react-core';
+
 import { CardLoader } from '../../presentational-components/shared/loader-placeholders';
-import { Bullseye, Text, TextVariants, Gallery } from '@patternfly/react-core';
 
 const NoItems = () => (
-  <Bullseye>
+  <div>
     <Text component={ TextVariants.h1 }>No items found</Text>
-  </Bullseye>
+  </div>
 );
 
-const ContentGallery = ({ isLoading, items }) => isLoading ? <CardLoader /> : (
-  <Section type="content">
-    <Gallery gutter="md" className="content-gallery">
-      { items.length > 0 ? items : <NoItems /> }
-    </Gallery>
-  </Section>
-);
+const ContentGallery = ({ isLoading, items, renderEmptyState }) =>
+  isLoading ?
+    <CardLoader /> :
+    items.length === 0
+      ? renderEmptyState
+        ? renderEmptyState()
+        : <NoItems />
+      : (
+        <Section type="content">
+          <Gallery gutter="md" className="content-gallery">
+            { items }
+          </Gallery>
+        </Section>
+      );
 
 ContentGallery.propTypes = {
-  isLoading: propTypes.bool,
-  items: propTypes.array
+  isLoading: PropTypes.bool,
+  items: PropTypes.array,
+  renderEmptyState: PropTypes.func
 };
 export default ContentGallery;

--- a/src/smart-components/platform/platforms.js
+++ b/src/smart-components/platform/platforms.js
@@ -3,12 +3,20 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Route, Switch } from 'react-router-dom';
 import { Section } from '@red-hat-insights/insights-frontend-components';
+import {
+  Text,
+  TextContent,
+  TextVariants
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+
 import ContentGallery from '../content-gallery/content-gallery';
 import PlatformCard from '../../presentational-components/platform/platform-card';
 import PlatformToolbar from '../../presentational-components/platform/platform-toolbar';
 import { fetchPlatforms } from '../../redux/actions/platform-actions';
 import { scrollToTop } from '../../helpers/shared/helpers';
 import Platform from './platform';
+import ContentGalleryEmptyState from '../../presentational-components/shared/content-gallery-empty-state';
 
 const platformsRoutes = {
   platforms: '',
@@ -30,6 +38,23 @@ class Platforms extends Component {
 
     handleFilterChange = filterValue => this.setState({ filterValue })
 
+    renderEmptyStateDescription = () => (
+      <Fragment>
+        <TextContent>
+          <Text component={ TextVariants.p }>
+            Configure a source in order to add products to portfolios.
+          </Text>
+          <Text component={ TextVariants.p }>
+            To connect to a source, go to <a href={ `${document.baseURI}hybrid/settings/catalog-sources` }>Catalog sources</a>&nbsp;
+            under <a href="javascript:void(0)">Settings</a>
+          </Text>
+          <Text component={ TextVariants.p }>
+            <a href="javascript:void(0)">Learn more in the documentation</a>
+          </Text>
+        </TextContent>
+      </Fragment>
+    )
+
     renderPlatforms = () => {
       const filteredItems = {
         items: this.props.platforms
@@ -40,7 +65,16 @@ class Platforms extends Component {
       return (
         <Fragment>
           <PlatformToolbar onFilterChange={ this.handleFilterChange } searchValue={ this.state.filterValue } title="Platforms" />
-          <ContentGallery { ...filteredItems } />
+          <ContentGallery
+            { ...filteredItems }
+            renderEmptyState={ () => (
+              <ContentGalleryEmptyState
+                title="No platforms yet"
+                renderDescription={ this.renderEmptyStateDescription }
+                Icon={ SearchIcon }
+              />
+            ) }
+          />
         </Fragment>
       );
     }

--- a/src/smart-components/portfolio/portfolio.js
+++ b/src/smart-components/portfolio/portfolio.js
@@ -1,7 +1,8 @@
 import React, { Component, Fragment } from 'react';
-import { withRouter, Route, Switch } from 'react-router-dom';
+import { withRouter, Route, Switch, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import propTypes from 'prop-types';
+import { Button } from '@patternfly/react-core';
 import ContentGallery from '../content-gallery/content-gallery';
 import { fetchSelectedPortfolio, fetchPortfolioItemsWithPortfolio } from '../../redux/actions/portfolio-actions';
 import AddProductsToPortfolio from './add-products-to-portfolio';
@@ -17,6 +18,8 @@ import { filterServiceOffering } from '../../helpers/shared/helpers';
 import TopToolbar, { TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
 import PortfolioItemDetail from './portfolio-item-detail/portfolio-item-detail';
 import SharePortfolioModal from './share-portfolio-modal';
+import ContentGalleryEmptyState, { EmptyStatePrimaryAction } from '../../presentational-components/shared/content-gallery-empty-state';
+import { SearchIcon } from '@patternfly/react-icons';
 
 class Portfolio extends Component {
   state = {
@@ -69,6 +72,15 @@ class Portfolio extends Component {
     this.setState({ filterValue });
   };
 
+  renderEmptyState = () => (
+    <ContentGalleryEmptyState
+      Icon={ SearchIcon }
+      title={ `No products in ${this.props.portfolio.name} portfolio` }
+      description="You haven’t added any products to the portfolio"
+      PrimaryAction={ () => <EmptyStatePrimaryAction url={ `${this.props.match.url}/add-products` } label="Add products" /> }
+    />
+  )
+
   renderProducts = ({ title, filteredItems, addProductsRoute, removeProductsRoute,
     editPortfolioRoute, removePortfolioRoute, sharePortfolioRoute }) => (
     <Fragment>
@@ -89,7 +101,7 @@ class Portfolio extends Component {
       <Route exact path="/portfolios/detail/:id/remove-portfolio" component={ RemovePortfolioModal } />
       <Route exact path="/portfolios/detail/:id/share-portfolio" component={ SharePortfolioModal } />
       <Route exact path="/portfolios/detail/:id/order/:itemId" render={ props => <OrderModal { ...props } closeUrl={ this.props.match.url } /> } />
-      <ContentGallery { ...filteredItems } />
+      <ContentGallery { ...filteredItems } renderEmptyState={ this.renderEmptyState } />
     </Fragment>
   )
 

--- a/src/smart-components/portfolio/portfolio.js
+++ b/src/smart-components/portfolio/portfolio.js
@@ -1,8 +1,7 @@
 import React, { Component, Fragment } from 'react';
-import { withRouter, Route, Switch, Link } from 'react-router-dom';
+import { withRouter, Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
 import propTypes from 'prop-types';
-import { Button } from '@patternfly/react-core';
 import ContentGallery from '../content-gallery/content-gallery';
 import { fetchSelectedPortfolio, fetchPortfolioItemsWithPortfolio } from '../../redux/actions/portfolio-actions';
 import AddProductsToPortfolio from './add-products-to-portfolio';

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -1,17 +1,20 @@
 import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
 import propTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
-import ContentGallery from '../content-gallery/content-gallery';
-import PortfolioCard from '../../presentational-components/portfolio/porfolio-card';
-import PortfoliosFilterToolbar from '../../presentational-components/portfolio/portfolios-filter-toolbar';
-import { fetchPortfolios } from '../../redux/actions/portfolio-actions';
+import { SearchIcon } from '@patternfly/react-icons';
+
+import Portfolio from './portfolio';
 import AddPortfolio from './add-portfolio-modal';
+import SharePortfolio from './share-portfolio-modal';
 import RemovePortfolio from './remove-portfolio-modal';
 import { scrollToTop } from '../../helpers/shared/helpers';
-import Portfolio from './portfolio';
+import ContentGallery from '../content-gallery/content-gallery';
+import { fetchPortfolios } from '../../redux/actions/portfolio-actions';
+import PortfolioCard from '../../presentational-components/portfolio/porfolio-card';
+import PortfoliosFilterToolbar from '../../presentational-components/portfolio/portfolios-filter-toolbar';
 import TopToolbar, { TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
-import SharePortfolio from './share-portfolio-modal';
+import ContentGalleryEmptyState, { EmptyStatePrimaryAction } from '../../presentational-components/shared/content-gallery-empty-state';
 
 const portfoliosRoutes = {
   portfolios: '',
@@ -53,7 +56,14 @@ class Portfolios extends Component {
         <Route exact path="/portfolios/edit/:id" component={ AddPortfolio } />
         <Route exact path="/portfolios/remove/:id" component={ RemovePortfolio } />
         <Route exact path="/portfolios/share/:id" component={ SharePortfolio } />
-        <ContentGallery { ...filteredItems } />
+        <ContentGallery { ...filteredItems } renderEmptyState={ () => (
+          <ContentGalleryEmptyState
+            title="No portfolios"
+            Icon={ SearchIcon }
+            description="You haven’t created a portfolio yet."
+            PrimaryAction={ () => <EmptyStatePrimaryAction url="/portfolios/add-portfolio" label="Create portfolio" /> }
+          />
+        ) } />
       </Fragment>
     );}
 

--- a/src/test/smart-components/content-gallery/__snapshots__/content-gallery.test.js.snap
+++ b/src/test/smart-components/content-gallery/__snapshots__/content-gallery.test.js.snap
@@ -65,46 +65,20 @@ exports[`<ContentGallery /> should render no items placeholder 1`] = `
   isLoading={false}
   items={Array []}
 >
-  <Section
-    type="content"
-  >
-    <section
-      className="ins-l-content"
-    >
-       
-      <Gallery
-        className="content-gallery"
-        gutter="md"
+  <NoItems>
+    <div>
+      <Text
+        className=""
+        component="h1"
       >
-        <div
-          className="pf-l-gallery pf-m-gutter content-gallery"
+        <h1
+          className=""
+          data-pf-content={true}
         >
-          <NoItems>
-            <Bullseye
-              className=""
-              component="div"
-            >
-              <div
-                className="pf-l-bullseye"
-              >
-                <Text
-                  className=""
-                  component="h1"
-                >
-                  <h1
-                    className=""
-                    data-pf-content={true}
-                  >
-                    No items found
-                  </h1>
-                </Text>
-              </div>
-            </Bullseye>
-          </NoItems>
-        </div>
-      </Gallery>
-       
-    </section>
-  </Section>
+          No items found
+        </h1>
+      </Text>
+    </div>
+  </NoItems>
 </ContentGallery>
 `;

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -213,6 +213,7 @@ describe('<Portfolio />', () => {
       platformReducer: { platforms: []},
       portfolioReducer: {
         ...initialState.portfolioReducer,
+        selectedPortfolio: { name: 'Foo' },
         portfolioItems: [{
           id: 123,
           name: 'Foo',


### PR DESCRIPTION
### Changes
- added empty states for platforms portfolios and portfolio screens (not add/remove portfolio item screens)
- Icons is mostly subject to change but changing that is just a matter of importing different icon from PF.

All of them look similar just different text

![screenshot-ci foo redhat com-1337-2019 04 11-16-43-35](https://user-images.githubusercontent.com/22619452/55966712-34508080-5c79-11e9-92a7-d3158e6e8ed0.png)
