### PR TITLE
Fixed webpack SCSS tree shaking.

### DIFF
--- a/config/base.webpack.config.js
+++ b/config/base.webpack.config.js
@@ -37,7 +37,7 @@ const webpackConfig = {
     }, {
       test: /\.s?[ac]ss$/,
       use: [
-        process.env.NODE_ENV === 'production' ? 'style-loader' : MiniCssExtractPlugin.loader,
+        MiniCssExtractPlugin.loader,
         {
           loader: 'css-loader'
         },

--- a/package.json
+++ b/package.json
@@ -113,5 +113,7 @@
   "insights": {
     "appname": "catalog"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "*.scss"
+  ]
 }


### PR DESCRIPTION
### Bugixes
- CSS assets were not build in production environment
  - webpack tree shaking was also removing all scss files because they were not explicitly referenced.
  - added SCSS files to sideeffects
  - also using just `MiniCssExtractPlugin` instead of `style-loader`.

### Before
![screenshot-ci cloud paas upshift redhat com-2019 04 15-10-06-42](https://user-images.githubusercontent.com/22619452/56117351-2c8a2800-5f68-11e9-96d5-244805df26d9.png)

### After
![screenshot-ci foo redhat com-1337-2019 04 15-09-55-35](https://user-images.githubusercontent.com/22619452/56117363-31e77280-5f68-11e9-9c17-f3712cffc38f.png)
