### PR TITLE
Added empty states for add products to portfolio screen.

### DIFF
--- a/src/smart-components/portfolio/add-products-to-portfolio/add-products-gallery.js
+++ b/src/smart-components/portfolio/add-products-to-portfolio/add-products-gallery.js
@@ -1,11 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ContentGallery from '../../content-gallery/content-gallery';
+import { SearchIcon } from '@patternfly/react-icons';
 
-const AddProductsGallery = props => <ContentGallery editMode = { true } { ...props } />;
+import ContentGallery from '../../content-gallery/content-gallery';
+import ContentGalleryEmptyState from '../../../presentational-components/shared/content-gallery-empty-state';
+
+const EmptyState = ({ platform }) => (
+  <ContentGalleryEmptyState
+    Icon={ SearchIcon }
+    title={ platform ? 'No products match filter parameters' : 'Please choose platform' }
+    description={ platform
+      ? 'Please try to extend your search parameters '
+      : 'In order to select products for your portfolio you must choose platform first' }
+  />
+);
+
+EmptyState.propTypes = {
+  platform: PropTypes.any
+};
+
+const AddProductsGallery = ({ platform, ...props }) => (
+  <ContentGallery
+    editMode = { true }
+    { ...props }
+    renderEmptyState={ () => <EmptyState platform={ platform } /> } />
+);
 
 AddProductsGallery.propTypes = {
-  checkedItems: PropTypes.arrayOf(PropTypes.string)
+  checkedItems: PropTypes.arrayOf(PropTypes.string),
+  platform: PropTypes.any
 };
 
 AddProductsGallery.defaultProps = {

--- a/src/smart-components/portfolio/add-products-to-portfolio/index.js
+++ b/src/smart-components/portfolio/add-products-to-portfolio/index.js
@@ -78,6 +78,7 @@ const AddProductsToPortfolio = ({
         { meta && <AddProductsPagination meta={ meta } platformId={ selectedPlatform.id } /> }
       </PortfolioOrderToolbar>
       <AddProductsGallery
+        platform={ !!selectedPlatform }
         checkedItems={ checkedItems }
         isLoading={ isLoading }
         items={ renderGalleryItems(items, itemId => setCheckedItems(checkItem(itemId)), checkedItems, searchValue) }

--- a/src/test/smart-components/portfolio/add-products-to-portfolio/__snapshots__/add-products-gallery.test.js.snap
+++ b/src/test/smart-components/portfolio/add-products-to-portfolio/__snapshots__/add-products-gallery.test.js.snap
@@ -4,5 +4,6 @@ exports[`<AddProductsGallery /> should render correctly 1`] = `
 <ContentGallery
   checkedItems={Array []}
   editMode={true}
+  renderEmptyState={[Function]}
 />
 `;


### PR DESCRIPTION
### Changes
- added empty states for add products to portfolio screen
  - one when no platform is selected
  - one when filter does not match any products
  - this is going to change probably soon. Just wanted to get rid of that ugly string

cc @sbuenafe-rh

### Before
![screenshot-ci cloud paas upshift redhat com-2019 04 16-15-15-21](https://user-images.githubusercontent.com/22619452/56212521-76ebd180-605a-11e9-87df-baa07c082ac7.png)

### After
![screenshot-ci foo redhat com-1337-2019 04 16-15-15-41](https://user-images.githubusercontent.com/22619452/56212552-89660b00-605a-11e9-8cbc-dc58370dec1a.png)

![screenshot-ci foo redhat com-1337-2019 04 16-15-15-52](https://user-images.githubusercontent.com/22619452/56212555-8b2fce80-605a-11e9-861d-fdb651c553d4.png)
