### PR TITLE
Add NODE_OPTIONS to avoid fatal error during build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache:
   - "$HOME/.npm"
 node_js:
 - '10'
+env:
+  global:
+  - NODE_OPTIONS="--max-old-space-size=4096 --max_old_space_size=4096"
 install:
 - npm install
 - npm install -g codecov


### PR DESCRIPTION
Moving var out of travis config and into .travis.yml

Avoids build error:
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory