### PR TITLE
Moved portfolio toolbar buttons.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -150,3 +150,13 @@
     fill: #72767B
   }
 }
+
+.toolbar-override {
+  display: flex;
+  align-items: center;
+  .toolbar-override-item {
+    &:not(:last-child) {
+      margin-right: 16px;
+    }
+  }
+}

--- a/src/presentational-components/portfolio/portfolio-filter-toolbar.js
+++ b/src/presentational-components/portfolio/portfolio-filter-toolbar.js
@@ -1,8 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Button, Dropdown, DropdownItem, DropdownPosition,
-  DropdownSeparator, KebabToggle, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  KebabToggle,
+  LevelItem,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem
+} from '@patternfly/react-core';
+
+import { TopToolbarTitle } from '../shared/top-toolbar';
 import FilterToolbarItem from '../shared/filter-toolbar-item';
 
 const PortfolioFilterToolbar = ({
@@ -12,62 +23,74 @@ const PortfolioFilterToolbar = ({
   editPortfolioRoute,
   removePortfolioRoute,
   sharePortfolioRoute,
+  title,
   ...props
 }) => {
   const [ isKebabOpen, setKebabOpen ] = useState(false);
   return (
-    <Toolbar>
-      <ToolbarGroup>
-        <ToolbarItem>
-          <FilterToolbarItem { ...props } placeholder={ 'Filter by name...' }/>
-        </ToolbarItem>
-      </ToolbarGroup>
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Link to={ addProductsRoute }>
-            <Button isDisabled={ isLoading } variant="primary" aria-label="Add Products to Portfolio">
-              Add products
-            </Button>
-          </Link>
-        </ToolbarItem>
-      </ToolbarGroup>
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Link to={ removeProductsRoute }>
-            <Button isDisabled={ isLoading } variant="link" className="destructive-color" aria-label="Remove Products from Portfolio">
-              Remove products
-            </Button>
-          </Link>
-        </ToolbarItem>
-        <ToolbarItem>
-          <Dropdown
-            onToggle={ setKebabOpen }
-            position={ DropdownPosition.right }
-            toggle={ <KebabToggle onToggle={ setKebabOpen }/> }
-            isOpen={ isKebabOpen }
-            isPlain
-            dropdownItems={ [
-              <DropdownItem aria-label="Share Portfolio" key="share-portfolio">
-                <Link to={ sharePortfolioRoute } role="link" className="pf-c-dropdown__menu-item">
-                  Share
-                </Link>
-              </DropdownItem>,
-              <DropdownSeparator key="separator"/>,
-              <DropdownItem aria-label="Edit Portfolio" key="edit-portfolio">
-                <Link to={ editPortfolioRoute } role="link" className="pf-c-dropdown__menu-item">
-                  Edit
-                </Link>
-              </DropdownItem>,
-              <DropdownItem aria-label="Remove Portfolio" key="delete-portfolio">
-                <Link to={ removePortfolioRoute } role="link" className="pf-c-dropdown__menu-item destructive-color">
-                  Delete
-                </Link>
-              </DropdownItem>
-            ] }
-          />
-        </ToolbarItem>
-      </ToolbarGroup>
-    </Toolbar>
+    <Fragment>
+      <TopToolbarTitle title={ title }>
+        <LevelItem>
+          <div className="toolbar-override">
+            <span className="toolbar-override-item">
+              <Link to={ sharePortfolioRoute }>
+                <Button variant="secondary">
+                        Share
+                </Button>
+              </Link>
+            </span>
+            <span>
+              <Link to={ editPortfolioRoute }>
+                <Button variant="link">
+                            Edit
+                </Button>
+              </Link>
+            </span>
+            <span>
+              <Dropdown
+                onToggle={ setKebabOpen }
+                position={ DropdownPosition.right }
+                toggle={ <KebabToggle onToggle={ setKebabOpen }/> }
+                isOpen={ isKebabOpen }
+                isPlain
+                dropdownItems={ [
+                  <DropdownItem aria-label="Remove Portfolio" key="delete-portfolio">
+                    <Link to={ removePortfolioRoute } role="link" className="pf-c-dropdown__menu-item destructive-color">
+                            Delete
+                    </Link>
+                  </DropdownItem>
+                ] }
+              />
+            </span>
+          </div>
+        </LevelItem>
+      </TopToolbarTitle>
+      <Toolbar>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <FilterToolbarItem { ...props } placeholder={ 'Filter by name...' }/>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Link to={ addProductsRoute }>
+              <Button isDisabled={ isLoading } variant="primary" aria-label="Add Products to Portfolio">
+                Add products
+              </Button>
+            </Link>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Link to={ removeProductsRoute }>
+              <Button isDisabled={ isLoading } variant="link" className="destructive-color" aria-label="Remove Products from Portfolio">
+                Remove products
+              </Button>
+            </Link>
+          </ToolbarItem>
+        </ToolbarGroup>
+      </Toolbar>
+    </Fragment>
   );
 };
 
@@ -77,7 +100,8 @@ PortfolioFilterToolbar.propTypes = {
   editPortfolioRoute: PropTypes.string.isRequired,
   sharePortfolioRoute: PropTypes.string.isRequired,
   removePortfolioRoute: PropTypes.string.isRequired,
-  removeProductsRoute: PropTypes.string.isRequired
+  removeProductsRoute: PropTypes.string.isRequired,
+  title: PropTypes.string
 };
 
 export default PortfolioFilterToolbar;

--- a/src/smart-components/portfolio/portfolio.js
+++ b/src/smart-components/portfolio/portfolio.js
@@ -14,7 +14,7 @@ import RemovePortfolioItems from './remove-portfolio-items';
 import { removePortfolioItems } from '../../helpers/portfolio/portfolio-helper';
 import OrderModal from '../common/order-modal';
 import { filterServiceOffering } from '../../helpers/shared/helpers';
-import TopToolbar, { TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
+import TopToolbar from '../../presentational-components/shared/top-toolbar';
 import PortfolioItemDetail from './portfolio-item-detail/portfolio-item-detail';
 import SharePortfolioModal from './share-portfolio-modal';
 import ContentGalleryEmptyState, { EmptyStatePrimaryAction } from '../../presentational-components/shared/content-gallery-empty-state';
@@ -84,8 +84,8 @@ class Portfolio extends Component {
     editPortfolioRoute, removePortfolioRoute, sharePortfolioRoute }) => (
     <Fragment>
       <TopToolbar>
-        <TopToolbarTitle title={ title }/>
         <PortfolioFilterToolbar
+          title={ title }
           searchValue={ this.state.filterValue }
           onFilterChange={ this.handleFilterChange }
           addProductsRoute={ addProductsRoute }

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-filter-toolbar.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-filter-toolbar.test.js.snap
@@ -1,159 +1,169 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PortfolioFilterToolbar /> should render correctly 1`] = `
-<Toolbar
-  className={null}
->
-  <ToolbarGroup
-    className={null}
-  >
-    <ToolbarItem
-      className={null}
-    >
-      <FilterToolbarItem
-        onFilterChange={[MockFunction]}
-        placeholder="Filter by name..."
-        searchValue=""
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-  <ToolbarGroup
-    className={null}
-  >
-    <ToolbarItem
-      className={null}
-    >
-      <Link
-        to="/add"
+<Fragment>
+  <TopToolbarTitle>
+    <LevelItem>
+      <div
+        className="toolbar-override"
       >
-        <Button
-          aria-label="Add Products to Portfolio"
-          className=""
-          component="button"
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          type="button"
-          variant="primary"
+        <span
+          className="toolbar-override-item"
         >
-          Add products
-        </Button>
-      </Link>
-    </ToolbarItem>
-  </ToolbarGroup>
-  <ToolbarGroup
-    className={null}
-  >
-    <ToolbarItem
-      className={null}
-    >
-      <Link
-        to="/remove-products"
-      >
-        <Button
-          aria-label="Remove Products from Portfolio"
-          className="destructive-color"
-          component="button"
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          type="button"
-          variant="link"
-        >
-          Remove products
-        </Button>
-      </Link>
-    </ToolbarItem>
-    <ToolbarItem
-      className={null}
-    >
-      <Dropdown
-        className=""
-        direction="down"
-        dropdownItems={
-          Array [
-            <Item
-              aria-label="Share Portfolio"
+          <Link>
+            <Button
+              aria-label={null}
               className=""
-              component="a"
-              href="#"
+              component="button"
+              isActive={false}
+              isBlock={false}
               isDisabled={false}
-              isHovered={false}
+              isFocus={false}
+              isHover={false}
+              type="button"
+              variant="secondary"
             >
-              <Link
-                className="pf-c-dropdown__menu-item"
-                role="link"
-              >
-                Share
-              </Link>
-            </Item>,
-            <Separator
+              Share
+            </Button>
+          </Link>
+        </span>
+        <span>
+          <Link
+            to="/edit"
+          >
+            <Button
+              aria-label={null}
               className=""
-              component="a"
-              href="#"
+              component="button"
+              isActive={false}
+              isBlock={false}
               isDisabled={false}
-              isHovered={false}
-            />,
-            <Item
-              aria-label="Edit Portfolio"
-              className=""
-              component="a"
-              href="#"
-              isDisabled={false}
-              isHovered={false}
+              isFocus={false}
+              isHover={false}
+              type="button"
+              variant="link"
             >
-              <Link
-                className="pf-c-dropdown__menu-item"
-                role="link"
-                to="/edit"
-              >
-                Edit
-              </Link>
-            </Item>,
-            <Item
-              aria-label="Remove Portfolio"
-              className=""
-              component="a"
-              href="#"
-              isDisabled={false}
-              isHovered={false}
-            >
-              <Link
-                className="pf-c-dropdown__menu-item destructive-color"
-                role="link"
-                to="/remove-portfolio"
-              >
-                Delete
-              </Link>
-            </Item>,
-          ]
-        }
-        isOpen={false}
-        isPlain={true}
-        onSelect={[Function]}
-        onToggle={[Function]}
-        position="right"
-        toggle={
-          <Kebab
-            aria-label="Actions"
+              Edit
+            </Button>
+          </Link>
+        </span>
+        <span>
+          <Dropdown
             className=""
-            id=""
-            isActive={false}
-            isDisabled={false}
-            isFocused={false}
-            isHovered={false}
+            direction="down"
+            dropdownItems={
+              Array [
+                <Item
+                  aria-label="Remove Portfolio"
+                  className=""
+                  component="a"
+                  href="#"
+                  isDisabled={false}
+                  isHovered={false}
+                >
+                  <Link
+                    className="pf-c-dropdown__menu-item destructive-color"
+                    role="link"
+                    to="/remove-portfolio"
+                  >
+                    Delete
+                  </Link>
+                </Item>,
+              ]
+            }
             isOpen={false}
-            isPlain={false}
+            isPlain={true}
+            onSelect={[Function]}
             onToggle={[Function]}
-            parentRef={null}
+            position="right"
+            toggle={
+              <Kebab
+                aria-label="Actions"
+                className=""
+                id=""
+                isActive={false}
+                isDisabled={false}
+                isFocused={false}
+                isHovered={false}
+                isOpen={false}
+                isPlain={false}
+                onToggle={[Function]}
+                parentRef={null}
+              />
+            }
           />
-        }
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</Toolbar>
+        </span>
+      </div>
+    </LevelItem>
+  </TopToolbarTitle>
+  <Toolbar
+    className={null}
+  >
+    <ToolbarGroup
+      className={null}
+    >
+      <ToolbarItem
+        className={null}
+      >
+        <FilterToolbarItem
+          onFilterChange={[MockFunction]}
+          placeholder="Filter by name..."
+          searchValue=""
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+    <ToolbarGroup
+      className={null}
+    >
+      <ToolbarItem
+        className={null}
+      >
+        <Link
+          to="/add"
+        >
+          <Button
+            aria-label="Add Products to Portfolio"
+            className=""
+            component="button"
+            isActive={false}
+            isBlock={false}
+            isDisabled={false}
+            isFocus={false}
+            isHover={false}
+            type="button"
+            variant="primary"
+          >
+            Add products
+          </Button>
+        </Link>
+      </ToolbarItem>
+    </ToolbarGroup>
+    <ToolbarGroup
+      className={null}
+    >
+      <ToolbarItem
+        className={null}
+      >
+        <Link
+          to="/remove-products"
+        >
+          <Button
+            aria-label="Remove Products from Portfolio"
+            className="destructive-color"
+            component="button"
+            isActive={false}
+            isBlock={false}
+            isDisabled={false}
+            isFocus={false}
+            isHover={false}
+            type="button"
+            variant="link"
+          >
+            Remove products
+          </Button>
+        </Link>
+      </ToolbarItem>
+    </ToolbarGroup>
+  </Toolbar>
+</Fragment>
 `;


### PR DESCRIPTION
### Changes
- moved portfolio share, edit, dropdown buttons to the top part of toolbar.

### Before
![screenshot-ci cloud paas upshift redhat com-2019 04 17-09-20-43](https://user-images.githubusercontent.com/22619452/56268626-1c05b900-60f2-11e9-8b7c-b7d66c30f92a.png)

### After
![screenshot-ci foo redhat com-1337-2019 04 17-09-20-30](https://user-images.githubusercontent.com/22619452/56268633-1f994000-60f2-11e9-912d-6e9c349af1c4.png)
