### PR TITLE
Added correct icons to order steps.

### DIFF
--- a/src/smart-components/order/create-order-row.js
+++ b/src/smart-components/order/create-order-row.js
@@ -1,22 +1,28 @@
 import React from 'react';
-import { CheckIcon, InProgressIcon } from '@patternfly/react-icons';
+import { CheckIcon, InProgressIcon, OutlinedTimesCircleIcon } from '@patternfly/react-icons';
 
 import { createDateString } from '../../helpers/shared/helpers';
 
 const completedWhiteList = state => [ 'Order Completed', 'finished' ].includes(state);
+const failedList = state => [ 'Failed' ].includes(state);
 
-const countFinishedSteps = step => step.filter(({ state }) => completedWhiteList(state));
+const countFinishedSteps = step => step.filter(({ state }) => !failedList(state) && completedWhiteList(state));
+
+const overrideOrderinitiated = (request = {}, orderItem = {}) => !failedList(orderItem.state) && completedWhiteList(request.state);
 
 const iconsMapper  = name => ({
   finished: <CheckIcon />,
-  'Order Completed': <CheckIcon />
+  'Order Completed': <CheckIcon />,
+  Failed: <OutlinedTimesCircleIcon />
 })[name] || <span><InProgressIcon /> &nbsp; Pending</span>;
 
 const createTableRows = order => [{
   reason: 'Order initiated',
   requester: 'System',
   updated_at: order.orderItems[0] && createDateString(order.orderItems[0].updated_at || order.orderItems[0].created_at),
-  state: order.orderItems[0] && order.orderItems[0].state
+  state: overrideOrderinitiated(order.requests[0], order.orderItems[0])
+    ? order.requests[0] && order.requests[0].state
+    : order.orderItems[0] && order.orderItems[0].state
 }, {
   reason: 'Approval',
   requester: 'System',
@@ -36,7 +42,12 @@ const createTableRows = order => [{
 
 const createOrderRow = order => {
   const initialSteps = createTableRows(order);
-  const finishedSteps = countFinishedSteps(initialSteps);
+  let finishedSteps = countFinishedSteps(initialSteps);
+  const firstFailedIndex = initialSteps.findIndex(({ state }) => failedList(state));
+  if (firstFailedIndex >= 0) {
+    finishedSteps = finishedSteps.slice(0, firstFailedIndex);
+  }
+
   const steps = initialSteps.map((item, index) => ({
     ...item,
     requester: index <= finishedSteps.length ? item.requester : null,


### PR DESCRIPTION
### Changes
- added correct icon for failed order step
- Add Order initiated override that will show success icon if it did not fail and approval was already approved
- hide step info after first failed step.

## Failed order
### Before

![screenshot-ci cloud paas upshift redhat com-2019 04 24-14-31-15](https://user-images.githubusercontent.com/22619452/56659667-079b6080-669e-11e9-8941-80a88cf89928.png)


### After
![screenshot-ci foo redhat com-1337-2019 04 24-14-30-00](https://user-images.githubusercontent.com/22619452/56659682-0f5b0500-669e-11e9-911a-b8a98f21e19f.png)

## Order initiated override
### Before
![screenshot-ci cloud paas upshift redhat com-2019 04 24-14-30-57](https://user-images.githubusercontent.com/22619452/56659706-20a41180-669e-11e9-9972-3585fd899f74.png)

### After
![screenshot-ci foo redhat com-1337-2019 04 24-14-29-49](https://user-images.githubusercontent.com/22619452/56659724-2a2d7980-669e-11e9-923b-006663427d22.png)

