### PR TITLE
Fixed order modal header icon and text sizing.

### DIFF
--- a/src/smart-components/common/order-modal.js
+++ b/src/smart-components/common/order-modal.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Modal } from '@patternfly/react-core';
+import { Modal, Level, LevelItem, Title, TextContent, Text, TextVariants } from '@patternfly/react-core';
 
-import CatItemSvg from '../../assets/images/vendor-openshift.svg';
-import ImageWithDefault from '../../presentational-components/shared/image-with-default';
+import { CATALOG_API_BASE } from '../../utilities/constants';
+import CardIcon from '../../presentational-components/shared/card-icon';
 import OrderServiceFormStepConfiguration from '../order/order-service-form-step-configuration';
 
 const OrderModal = ({ serviceData, closeUrl, history: { push }}) => serviceData ? (
@@ -14,10 +14,27 @@ const OrderModal = ({ serviceData, closeUrl, history: { push }}) => serviceData 
     title=""
     hideTitle
     onClose={ () => push(closeUrl) }
-    style={ { maxWidth: 800, minHeight: 300 } }
+    isLarge
   >
-    <ImageWithDefault src = { serviceData.imageUrl || CatItemSvg } width="40" />
-    { serviceData.name }
+    <div className="pf-u-mb-md">
+      <div style={ { float: 'left' } } className="pf-u-mr-sm">
+        <CardIcon height={ 64 } src={ `${CATALOG_API_BASE}/portfolio_items/${serviceData.id}/icon` } />
+      </div>
+      <Level>
+        <LevelItem className="elipsis-text-overflow">
+          <Title headingLevel="h2" size="3xl">
+            { serviceData.display_name }
+          </Title>
+        </LevelItem>
+      </Level>
+      <Level>
+        <LevelItem>
+          <TextContent>
+            <Text component={ TextVariants.small }>{ serviceData.name }</Text>
+          </TextContent>
+        </LevelItem>
+      </Level>
+    </div>
     <OrderServiceFormStepConfiguration closeUrl={ closeUrl } { ...serviceData } />
   </Modal>
 ) : null;

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -19,7 +19,7 @@ const PortfolioItemDetailToolbar = ({
 }) => (
   <Fragment>
     <TopToolbar>
-      <div style={ { float: 'left' } }>
+      <div style={ { float: 'left' } } className="pf-u-mr-sm">
         <CardIcon src={ `${CATALOG_API_BASE}/portfolio_items/${product.id}/icon` } height={ 64 }/>
       </div>
       <Level>


### PR DESCRIPTION
### Bugfixes
- fixed wrong icon for order modal
- fixed Heading sizing
- added portfolio display name to order modal header

fixes: #175 

### Before
![screenshot-ci cloud paas upshift redhat com-2019 04 25-10-00-18](https://user-images.githubusercontent.com/22619452/56719433-fc4d4100-6740-11e9-947d-2391026eac9b.png)

### After
![screenshot-ci foo redhat com-1337-2019 04 25-09-59-34](https://user-images.githubusercontent.com/22619452/56719426-f8b9ba00-6740-11e9-855a-5d45e347dba8.png)
