### PR TITLE
Fixed failed order step highlight.

### DIFF
--- a/src/smart-components/order/create-order-row.js
+++ b/src/smart-components/order/create-order-row.js
@@ -53,7 +53,7 @@ const createOrderRow = order => {
     requester: index <= finishedSteps.length ? item.requester : null,
     state: index <= finishedSteps.length ? iconsMapper(item.state) : null,
     updated_at: index <= finishedSteps.length ? item.updated_at : null,
-    isFinished: index === finishedSteps.length - 1
+    isFinished: firstFailedIndex >= 0 ? (finishedSteps.length === index) : (finishedSteps.length - 1 === index)
   }));
 
   return { steps, finishedSteps };

--- a/src/smart-components/order/create-order-row.js
+++ b/src/smart-components/order/create-order-row.js
@@ -8,7 +8,7 @@ const failedList = state => [ 'Failed' ].includes(state);
 
 const countFinishedSteps = step => step.filter(({ state }) => !failedList(state) && completedWhiteList(state));
 
-const overrideOrderinitiated = (request = {}, orderItem = {}) => !failedList(orderItem.state) && completedWhiteList(request.state);
+// const overrideOrderinitiated = (request = {}, orderItem = {}) => !failedList(orderItem.state) && completedWhiteList(request.state);
 
 const iconsMapper  = name => ({
   finished: <CheckIcon />,
@@ -20,9 +20,7 @@ const createTableRows = order => [{
   reason: 'Order initiated',
   requester: 'System',
   updated_at: order.orderItems[0] && createDateString(order.orderItems[0].updated_at || order.orderItems[0].created_at),
-  state: overrideOrderinitiated(order.requests[0], order.orderItems[0])
-    ? order.requests[0] && order.requests[0].state
-    : order.orderItems[0] && order.orderItems[0].state
+  state: 'finished'
 }, {
   reason: 'Approval',
   requester: 'System',


### PR DESCRIPTION
### TO DO
- more info about state for order steps: https://github.com/ManageIQ/catalog-ui/issues/173#issuecomment-486568497

solves #173 

### Changes
- added correct highlight to failed order steps
- order initiated is always shown as successful 

### Before
![screenshot-ci cloud paas upshift redhat com-2019 04 25-10-24-15](https://user-images.githubusercontent.com/22619452/56721020-4edc2c80-6744-11e9-9ca7-6191af5512f2.png)

### After
![screenshot-ci foo redhat com-1337-2019 04 29-10-45-17](https://user-images.githubusercontent.com/22619452/56885138-fec6d800-6a6b-11e9-97b0-81c039c2071c.png)

