### PR TITLE
Added horizontal scroll to progress message modal.

### DIFF
--- a/src/smart-components/order/order-messages-modal.js
+++ b/src/smart-components/order/order-messages-modal.js
@@ -18,6 +18,7 @@ const OrderMessagesModal = ({ history: { push }, match: { params: { orderItemId 
       title={ `Progress messages of order item with id: ${orderItemId}` }
       isLarge
       onClose={ () => push('/orders') }
+      style={ { overflowX: 'scroll' } }
     >
       <pre>
         { JSON.stringify(messages, null, 2) }


### PR DESCRIPTION
### Changes
- horizontal scroll bar to progress messages modal.

Is caused by wrong response format on the message attribute. Sometimes it returns ruby hash instead of JSON so its nor formatted properly by `JSON.stringyfy`.

![screenshot-ci foo redhat com-1337-2019 05 02-10-05-31](https://user-images.githubusercontent.com/22619452/57062884-d6d0b200-6cc1-11e9-950a-868f102b5217.png)
