### PR TITLE
Fixed steps highlighting and progress.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -125,9 +125,16 @@
       &.finished {
           .requests-step-label {
             span:first-child {
-              background-color: #007BBA;
+              background-color: var(--pf-global--primary-color--100);
               color: #FFFFFF
+            }
           }
+          &.failed {
+            .requests-step-label {
+              span:first-child {
+                background-color: var(--pf-global--danger-color--100);
+              }
+            }
         }
       }
       td {

--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -29,7 +29,12 @@ export async function sendSubmitOrder({ service_parameters: { providerControlPar
 }
 
 export function listRequests() {
-  return requestsApi.listRequests();
+  return requestsApi.listRequests().then(data => ({
+    ...data,
+    data: data.data.map(({ decision, ...item }) => ({
+      ...item,
+      state: decision
+    })) }));
 }
 
 export function listOrderItems() {

--- a/src/redux/actions/order-actions.js
+++ b/src/redux/actions/order-actions.js
@@ -61,7 +61,7 @@ const linkOrders = (orders, orderItems, requests) => orders.map(order => ({
   requests: requests.filter(({ content: { order_id }}) => order_id == order.id) // eslint-disable-line eqeqeq
 }));
 
-const separateOrders = orders => orders.reduce((acc, curr) => [ 'Completed', 'Failed' ].includes(curr.state) ? ({
+const separateOrders = orders => orders.reduce((acc, curr) => [ 'Completed', 'Failed', 'Denied' ].includes(curr.state) ? ({
   current: acc.current,
   past: [ ...acc.past, curr ]
 }) : ({

--- a/src/smart-components/order/create-order-row.js
+++ b/src/smart-components/order/create-order-row.js
@@ -3,8 +3,8 @@ import { CheckIcon, InProgressIcon, OutlinedTimesCircleIcon } from '@patternfly/
 
 import { createDateString } from '../../helpers/shared/helpers';
 
-const completedWhiteList = state => [ 'Order Completed', 'finished', 'Completed' ].includes(state);
-const failedList = state => [ 'Failed' ].includes(state);
+const completedWhiteList = state => [ 'Order Completed', 'finished', 'Completed', 'approved' ].includes(state);
+const failedList = state => [ 'Failed', 'denied', 'Denied' ].includes(state);
 
 const countFinishedSteps = step => step.filter(({ state }) => !failedList(state) && completedWhiteList(state));
 
@@ -14,7 +14,9 @@ const iconsMapper  = name => ({
   finished: <CheckIcon />,
   'Order Completed': <CheckIcon />,
   Completed: <CheckIcon />,
-  Failed: <OutlinedTimesCircleIcon />
+  approved: <CheckIcon />,
+  Failed: <OutlinedTimesCircleIcon />,
+  denied: <OutlinedTimesCircleIcon />
 })[name] || <span><InProgressIcon /> &nbsp; Pending</span>;
 
 const createTableRows = order => [{

--- a/src/smart-components/order/create-order-row.js
+++ b/src/smart-components/order/create-order-row.js
@@ -3,7 +3,7 @@ import { CheckIcon, InProgressIcon, OutlinedTimesCircleIcon } from '@patternfly/
 
 import { createDateString } from '../../helpers/shared/helpers';
 
-const completedWhiteList = state => [ 'Order Completed', 'finished' ].includes(state);
+const completedWhiteList = state => [ 'Order Completed', 'finished', 'Completed' ].includes(state);
 const failedList = state => [ 'Failed' ].includes(state);
 
 const countFinishedSteps = step => step.filter(({ state }) => !failedList(state) && completedWhiteList(state));
@@ -13,6 +13,7 @@ const countFinishedSteps = step => step.filter(({ state }) => !failedList(state)
 const iconsMapper  = name => ({
   finished: <CheckIcon />,
   'Order Completed': <CheckIcon />,
+  Completed: <CheckIcon />,
   Failed: <OutlinedTimesCircleIcon />
 })[name] || <span><InProgressIcon /> &nbsp; Pending</span>;
 
@@ -55,7 +56,7 @@ const createOrderRow = order => {
     requester: index <= finishedSteps.length ? item.requester : null,
     state: index <= finishedSteps.length ? iconsMapper(item.state) : null,
     updated_at: index <= finishedSteps.length ? item.updated_at : null,
-    isFinished: firstFailedIndex >= 0 ? (finishedSteps.length === index) : (finishedSteps.length - 1 === index)
+    isFinished: finishedSteps.length === index
   }));
 
   return { steps, finishedSteps };

--- a/src/smart-components/order/order-detail-table.js
+++ b/src/smart-components/order/order-detail-table.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { MessagesIcon } from '@patternfly/react-icons';
 import StepLabel from './step-label';
 
-const OrderDetailTable = ({ requests }) => (
+const OrderDetailTable = ({ requests, orderState }) => (
   <Fragment>
     <table className="requests-table">
       <thead>
@@ -25,7 +25,7 @@ const OrderDetailTable = ({ requests }) => (
       </thead>
       <tbody>
         { requests.map(({ reason, requester, updated_at, state, isFinished }, index) => (
-          <tr key={ index } className={ isFinished ? 'finished' : '' }>
+          <tr key={ index } className={ `${isFinished ? 'finished' : ''} ${orderState === 'Failed' ? 'failed' : ''}` }>
             <td><StepLabel index={ index } text={ reason } /></td>
             <td>{ requester }</td>
             <td>{ updated_at }</td>
@@ -50,7 +50,8 @@ OrderDetailTable.propTypes = {
     requester: PropTypes.string,
     updated_at: PropTypes.string,
     state: PropTypes.oneOfType([ PropTypes.string, PropTypes.node ])
-  })).isRequired
+  })).isRequired,
+  orderState: PropTypes.string
 };
 
 export default withRouter(OrderDetailTable);

--- a/src/smart-components/order/order-detail-table.js
+++ b/src/smart-components/order/order-detail-table.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { MessagesIcon } from '@patternfly/react-icons';
 import StepLabel from './step-label';
 
+const orderFailedStates = state => [ 'Failed', 'Denied' ].includes(state);
+
 const OrderDetailTable = ({ requests, orderState }) => (
   <Fragment>
     <table className="requests-table">
@@ -25,7 +27,7 @@ const OrderDetailTable = ({ requests, orderState }) => (
       </thead>
       <tbody>
         { requests.map(({ reason, requester, updated_at, state, isFinished }, index) => (
-          <tr key={ index } className={ `${isFinished ? 'finished' : ''} ${orderState === 'Failed' ? 'failed' : ''}` }>
+          <tr key={ index } className={ `${isFinished ? 'finished' : ''} ${orderFailedStates(orderState) ? 'failed' : ''}` }>
             <td><StepLabel index={ index } text={ reason } /></td>
             <td>{ requester }</td>
             <td>{ updated_at }</td>

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -114,7 +114,7 @@ class OrderItem extends Component {
           />
         </DataListItemRow>
         <DataListContent aria-label={ `${item.id}-content` } isHidden={ !isExpanded }>
-          { isExpanded && <OrderDetailTable requests={ steps } /> }
+          { isExpanded && <OrderDetailTable requests={ steps } orderState={ item.state } /> }
         </DataListContent>
       </DataListItem>
     );

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -107,14 +107,22 @@ class OrderItem extends Component {
                   </SplitItem>
                 </Split>
               </DataListCell>,
-              <DataListCell key="2" style={ { alignSelf: 'center' } }>
-                <OrderSteps requests={ finishedSteps } />
+              <DataListCell key="2" style={ { alignSelf: item.state === 'Completed' ? 'flex-end' : 'center' } }>
+                { item.state === 'Completed'
+                  ? (
+                    <div style={ { minWidth: 200, textAlign: 'end' } }>
+                      <a href={ item.orderItems && item.orderItems[0].external_url }>
+                        Manage product
+                      </a>
+                    </div>)
+                  : <OrderSteps requests={ finishedSteps } />
+                }
               </DataListCell>
             ] }
           />
         </DataListItemRow>
         <DataListContent aria-label={ `${item.id}-content` } isHidden={ !isExpanded }>
-          { isExpanded && <OrderDetailTable requests={ steps } orderState={ item.state } /> }
+          { isExpanded && <OrderDetailTable requests={ steps } orderState={ item.state } orderItem={ item.orderItems && item.orderItems[0] }  /> }
         </DataListContent>
       </DataListItem>
     );


### PR DESCRIPTION
solves: https://github.com/ManageIQ/catalog-ui/issues/190

### Bug fixes
- wrong steps progress when order was successfully finished
- wrong progress when request was denied

### Changes
- red highlight color on failed order step number
- moved highlight to step in progress from last finished step
- added manage product link if the order was completed

## Progress
### Before
![screenshot-ci cloud paas upshift redhat com-2019 05 02-10-49-32](https://user-images.githubusercontent.com/22619452/57064968-4053bf00-6cc8-11e9-9704-4d9355644ccb.png)

### After
![screenshot-ci foo redhat com-1337-2019 05 02-15-22-29](https://user-images.githubusercontent.com/22619452/57078336-5d9b8400-6cee-11e9-881d-0c7aef0408fc.png)


## Failed step
![screenshot-ci foo redhat com-1337-2019 05 02-10-52-27](https://user-images.githubusercontent.com/22619452/57065017-62e5d800-6cc8-11e9-93ee-85164dbcdef1.png)

## Denied approval steps
If the approval request has state `denied` and the whole order has state `Denied`
![screenshot-ci foo redhat com-1337-2019 05 02-14-49-40](https://user-images.githubusercontent.com/22619452/57076298-9ab14780-6ce9-11e9-9399-756911a50766.png)
