### PR TITLE
Enable portfolio item workflow edit.

### DIFF
--- a/src/presentational-components/shared/pf4-select-wrapper.js
+++ b/src/presentational-components/shared/pf4-select-wrapper.js
@@ -52,11 +52,12 @@ const Pf4SelectWrapper = ({
   formOptions,
   dataType,
   initialKey,
+  id,
   ...rest
 }) => {
   const { error, touched } = meta;
   const showError = touched && error;
-  const { name, id } = rest.input;
+  const { name } = rest.input;
 
   return (
     <FormGroup
@@ -75,6 +76,7 @@ const Pf4SelectWrapper = ({
 
 Pf4SelectWrapper.propTypes = {
   componentType: PropTypes.string,
+  id: PropTypes.string,
   label: PropTypes.string,
   isRequired: PropTypes.bool,
   helperText: PropTypes.string,

--- a/src/redux/reducers/portfolio-reducer.js
+++ b/src/redux/reducers/portfolio-reducer.js
@@ -40,6 +40,7 @@ export default {
   [`${FETCH_PORTFOLIO}_FULFILLED`]: selectPortfolio,
   [FILTER_PORTFOLIO_ITEMS]: filterPortfolios,
   [`${SELECT_PORTFOLIO_ITEM}_FULFILLED`]: setPortfolioItem,
+  [SELECT_PORTFOLIO_ITEM]: setPortfolioItem,
   [`${UPDATE_PORTFOLIO}_FULFILLED`]: selectPortfolio,
   [SET_LOADING_STATE]: setLoadingState
 };

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import { LevelItem } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownPosition, KebabToggle, LevelItem } from '@patternfly/react-core';
 import ButtonWithSpinner from '../../../presentational-components/shared/button-with-spinner';
 
 const DetailToolbarActions = ({ orderUrl, editUrl, isOpen, setOpen, isFetching }) => ( // eslint-disable-line no-unused-vars
@@ -12,25 +12,23 @@ const DetailToolbarActions = ({ orderUrl, editUrl, isOpen, setOpen, isFetching }
       </Link>
     </LevelItem>
     {
-      /**
-       *<LevelItem style={ { marginLeft: 16 } }>
-       *  <Dropdown
-       *    isPlain
-       *    onToggle={ setOpen }
-       *    onSelect={ () => setOpen(false) }
-       *    position={ DropdownPosition.right }
-       *    toggle={ <KebabToggle onToggle={ setOpen }/> }
-       *    isOpen={ isOpen }
-       *    dropdownItems={ [
-       *      <DropdownItem aria-label="Edit Portfolio" key="edit-portfolio">
-       *        <Link to={ editUrl } role="link" className="pf-c-dropdown__menu-item">
-       *            Edit
-       *        </Link>
-       *      </DropdownItem>
-       *    ] }
-       *  />
-       *</LevelItem>
-       */
+      <LevelItem style={ { marginLeft: 16 } }>
+        <Dropdown
+          isPlain
+          onToggle={ setOpen }
+          onSelect={ () => setOpen(false) }
+          position={ DropdownPosition.right }
+          toggle={ <KebabToggle onToggle={ setOpen }/> }
+          isOpen={ isOpen }
+          dropdownItems={ [
+            <DropdownItem aria-label="Edit Portfolio" key="edit-portfolio">
+              <Link to={ editUrl } role="link" className="pf-c-dropdown__menu-item">
+                   Edit
+              </Link>
+            </DropdownItem>
+          ] }
+        />
+      </LevelItem>
     }
   </Fragment>
 );

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
@@ -1,16 +1,17 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { Route } from 'react-router-dom';
+import { Grid, GridItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 import { allowNull } from '../../../helpers/shared/helpers';
+import Pf4SelectWrapper from '../../../presentational-components/shared/pf4-select-wrapper';
 
-/**const getWorkflowTitle = (workflows, workflowRef) => {
- * let workflow = workflows.find(({ value }) => value === workflowRef);
- * return workflow ? workflow.label : 'None';
- * };
- */
+const getWorkflowTitle = (workflows, workflowRef) => {
+  let workflow = workflows.find(({ value }) => value === workflowRef);
+  return workflow ? workflow.label : 'None';
+};
 
-const ItemDetailDescription = ({ product }) => (
+const ItemDetailDescription = ({ product, url, workflows, workflow, setWorkflow }) => (
   <Fragment>
     <TextContent>
       <Text component={ TextVariants.p }>{ product.description }</Text>
@@ -21,26 +22,24 @@ const ItemDetailDescription = ({ product }) => (
       <Text component={ TextVariants.p }><a href={ product.support_url } target="_blank" rel="noopener noreferrer">Learn more</a></Text>
       <Text component={ TextVariants.h6 }>Documentation</Text>
       <Text component={ TextVariants.p }><a href={ product.documentation_url } target="_blank" rel="noopener noreferrer">Doc link</a></Text>
-      { /**<Route exact path={ `${url}` } render={ () => (
-        *<Fragment>
-        *  <Text component={ TextVariants.h6 }>Approval workflow</Text>
-        *  <Text component={ TextVariants.p }>{ getWorkflowTitle(workflows, product.workflow_ref) }</Text>
-        *</Fragment>
+      <Route exact path={ `${url}` } render={ () => (
+        <Fragment>
+          <Text component={ TextVariants.h6 }>Approval workflow</Text>
+          <Text component={ TextVariants.p }>{ getWorkflowTitle(workflows, product.workflow_ref) }</Text>
+        </Fragment>
       ) } />
-      */ }
+
     </TextContent>
-    { /**
-     * <Route exact path={ `${url}/edit` } render={ () => (
-     *   <Grid>
-     *     <GridItem md={ 6 }>
-     *       <Pf4SelectWrapper input={ {
-     *         onChange: value => setWorkflow(value),
-     *         value: workflow || undefined
-     *       } } meta={ {} } label="Approval workflow" options={ workflows } id="change-workflow" />
-     *     </GridItem>
-     *   </Grid>
-     * ) } />
-     */ }
+    <Route exact path={ `${url}/edit` } render={ () => (
+      <Grid>
+        <GridItem md={ 6 }>
+          <Pf4SelectWrapper input={ {
+            onChange: value => setWorkflow(value),
+            value: workflow || undefined
+          } } meta={ {} } label="Approval workflow" options={ workflows } id="change-workflow" />
+        </GridItem>
+      </Grid>
+    ) } />
   </Fragment>
 );
 

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -33,7 +33,7 @@ const PortfolioItemDetailToolbar = ({
         </LevelItem>
         <LevelItem>
           <Level>
-            <Route exact path={ [ url, `${url}/order` ] } render={ (...args) => (
+            <Route exact path={ url } render={ (...args) => (
               <DetailToolbarActions
                 isOpen={ isOpen }
                 setOpen={ setOpen }

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { withRouter, Redirect, Route } from 'react-router-dom';
+import { withRouter, Route } from 'react-router-dom';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { Section } from '@redhat-cloud-services/frontend-components';
 
@@ -21,7 +21,6 @@ import { ProductLoaderPlaceholder } from '../../../presentational-components/sha
 const PortfolioItemDetail = ({
   match: { path, url, params: { portfolioItemId }},
   history: { push },
-  location: { pathname },
   source,
   product,
   portfolio,
@@ -47,13 +46,9 @@ const PortfolioItemDetail = ({
     setWorkflow(product.workflow_ref);
   }, [ isLoading ]);
 
-  const handleUpdate = () => {
-    updatePortfolioItem({ ...product, workflow_ref: workflow }).then(updatedItem => selectPortfolioItem(updatedItem.json())).then(() => push(url));
-  };
-
-  if (pathname.match(/\/product\/[0-9]+\/edit/)) {
-    return <Redirect to={ url } />;
-  }
+  const handleUpdate = () => updatePortfolioItem({ ...product, workflow_ref: workflow })
+  .then(updatedItem => selectPortfolioItem(updatedItem))
+  .then(() => push(url));
 
   if (isLoading) {
     return (
@@ -98,9 +93,6 @@ PortfolioItemDetail.propTypes = {
   portfolio: PropTypes.shape({
     id: PropTypes.string.isRequired
   }),
-  location: PropTypes.shape({
-    pathname: PropTypes.string.isRequired
-  }).isRequired,
   product: PropTypes.shape({
     id: PropTypes.string
   }).isRequired,

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -53,5 +53,141 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
       </Link>
     </div>
   </LevelItem>
+  <LevelItem
+    style={
+      Object {
+        "marginLeft": 16,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "marginLeft": 16,
+        }
+      }
+    >
+      <Dropdown
+        className=""
+        direction="down"
+        dropdownItems={
+          Array [
+            <Item
+              aria-label="Edit Portfolio"
+              className=""
+              component="a"
+              href="#"
+              isDisabled={false}
+              isHovered={false}
+            >
+              <Link
+                className="pf-c-dropdown__menu-item"
+                role="link"
+                to="foo/baz"
+              >
+                Edit
+              </Link>
+            </Item>,
+          ]
+        }
+        isOpen={false}
+        isPlain={true}
+        onSelect={[Function]}
+        onToggle={[MockFunction]}
+        position="right"
+        toggle={
+          <Kebab
+            aria-label="Actions"
+            className=""
+            id=""
+            isActive={false}
+            isDisabled={false}
+            isFocused={false}
+            isHovered={false}
+            isOpen={false}
+            isPlain={false}
+            onToggle={[MockFunction]}
+            parentRef={null}
+          />
+        }
+      >
+        <div
+          className="pf-c-dropdown"
+          onToggle={[MockFunction]}
+        >
+          <Kebab
+            aria-label="Actions"
+            ariaHasPopup={true}
+            className=""
+            id="pf-toggle-id-0"
+            isActive={false}
+            isDisabled={false}
+            isFocused={false}
+            isHovered={false}
+            isOpen={false}
+            isPlain={true}
+            key=".0"
+            onEnter={[Function]}
+            onToggle={[MockFunction]}
+            parentRef={null}
+          >
+            <Toggle
+              aria-label="Actions"
+              ariaHasPopup={true}
+              className=""
+              id="pf-toggle-id-0"
+              isActive={false}
+              isDisabled={false}
+              isFocused={false}
+              isHovered={false}
+              isOpen={false}
+              isPlain={true}
+              onEnter={[Function]}
+              onToggle={[MockFunction]}
+              parentRef={null}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="Actions"
+                className="pf-c-dropdown__toggle pf-m-plain"
+                disabled={false}
+                id="pf-toggle-id-0"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="button"
+              >
+                <EllipsisVIcon
+                  color="currentColor"
+                  size="sm"
+                  title={null}
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 192 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                      transform=""
+                    />
+                  </svg>
+                </EllipsisVIcon>
+              </button>
+            </Toggle>
+          </Kebab>
+        </div>
+      </Dropdown>
+    </div>
+  </LevelItem>
 </DetailToolbarActions>
 `;

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-description.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-description.test.js.snap
@@ -136,8 +136,41 @@ exports[`<ItemDetailDescription /> should render correctly 1`] = `
           </a>
         </p>
       </Text>
+      <Route
+        exact={true}
+        path="/base/url"
+        render={[Function]}
+      >
+        <Text
+          className=""
+          component="h6"
+        >
+          <h6
+            className=""
+            data-pf-content={true}
+          >
+            Approval workflow
+          </h6>
+        </Text>
+        <Text
+          className=""
+          component="p"
+        >
+          <p
+            className=""
+            data-pf-content={true}
+          >
+            None
+          </p>
+        </Text>
+      </Route>
     </div>
   </TextContent>
+  <Route
+    exact={true}
+    path="/base/url/edit"
+    render={[Function]}
+  />
 </ItemDetailDescription>
 `;
 
@@ -277,7 +310,193 @@ exports[`<ItemDetailDescription /> should render correctly in edit variant 1`] =
           </a>
         </p>
       </Text>
+      <Route
+        exact={true}
+        path="/base/url"
+        render={[Function]}
+      />
     </div>
   </TextContent>
+  <Route
+    exact={true}
+    path="/base/url/edit"
+    render={[Function]}
+  >
+    <Grid
+      className=""
+      gutter={null}
+      lg={null}
+      md={null}
+      sm={null}
+      span={null}
+      xl={null}
+    >
+      <div
+        className="pf-l-grid"
+      >
+        <GridItem
+          className=""
+          lg={null}
+          lgOffset={null}
+          lgRowSpan={null}
+          md={6}
+          mdOffset={null}
+          mdRowSpan={null}
+          offset={null}
+          rowSpan={null}
+          sm={null}
+          smOffset={null}
+          smRowSpan={null}
+          span={null}
+          xl={null}
+          xlOffset={null}
+          xlRowSpan={null}
+        >
+          <div
+            className="pf-l-grid__item pf-m-6-col-on-md"
+          >
+            <Pf4SelectWrapper
+              id="change-workflow"
+              input={
+                Object {
+                  "onChange": [Function],
+                  "value": "foo",
+                }
+              }
+              label="Approval workflow"
+              meta={Object {}}
+              options={
+                Array [
+                  Object {
+                    "label": "Foo",
+                    "value": "foo",
+                  },
+                  Object {
+                    "label": "Bar",
+                    "value": "bar",
+                  },
+                ]
+              }
+            >
+              <FormGroup
+                className=""
+                fieldId="change-workflow"
+                isInline={false}
+                isRequired={false}
+                isValid={true}
+                label="Approval workflow"
+              >
+                <div
+                  className="pf-c-form__group"
+                >
+                  <label
+                    className="pf-c-form__label"
+                    htmlFor="change-workflow"
+                  >
+                    Approval workflow
+                  </label>
+                  <Select
+                    id="change-workflow"
+                    input={
+                      Object {
+                        "onChange": [Function],
+                        "value": "foo",
+                      }
+                    }
+                    isValid={true}
+                    label="Approval workflow"
+                    options={
+                      Array [
+                        Object {
+                          "label": "Foo",
+                          "value": "foo",
+                        },
+                        Object {
+                          "label": "Bar",
+                          "value": "bar",
+                        },
+                      ]
+                    }
+                  >
+                    <FormSelect
+                      aria-label={null}
+                      className=""
+                      id="change-workflow"
+                      isDisabled={false}
+                      isValid={true}
+                      label="Approval workflow"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      value="foo"
+                    >
+                      <select
+                        aria-invalid={false}
+                        aria-label={null}
+                        className="pf-c-form-control"
+                        disabled={false}
+                        id="change-workflow"
+                        label="Approval workflow"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="foo"
+                      >
+                        <FormSelectOption
+                          className=""
+                          isDisabled={false}
+                          key="None"
+                          label="None"
+                          value=""
+                        >
+                          <option
+                            className=""
+                            disabled={false}
+                            value=""
+                          >
+                            None
+                          </option>
+                        </FormSelectOption>
+                        <FormSelectOption
+                          className=""
+                          isDisabled={false}
+                          key="foo"
+                          label="Foo"
+                          value="foo"
+                        >
+                          <option
+                            className=""
+                            disabled={false}
+                            value="foo"
+                          >
+                            Foo
+                          </option>
+                        </FormSelectOption>
+                        <FormSelectOption
+                          className=""
+                          isDisabled={false}
+                          key="bar"
+                          label="Bar"
+                          value="bar"
+                        >
+                          <option
+                            className=""
+                            disabled={false}
+                            value="bar"
+                          >
+                            Bar
+                          </option>
+                        </FormSelectOption>
+                      </select>
+                    </FormSelect>
+                  </Select>
+                </div>
+              </FormGroup>
+            </Pf4SelectWrapper>
+          </div>
+        </GridItem>
+      </div>
+    </Grid>
+  </Route>
 </ItemDetailDescription>
 `;


### PR DESCRIPTION
Adds back the link which takes the user to edit mode for portfolio item

### Changes
- enables workflow edit from portfolio item detail screen
  - mostly revert of https://github.com/ManageIQ/catalog-ui/pull/152/files

### Before
![screenshot-ci cloud paas upshift redhat com-2019 06 12-14-22-58](https://user-images.githubusercontent.com/22619452/59351097-e9f18b80-8d1d-11e9-86f5-59f9cc493730.png)


### After
![screenshot-ci foo redhat com-1337-2019 06 12-14-18-47](https://user-images.githubusercontent.com/22619452/59351111-efe76c80-8d1d-11e9-8f63-cefc9096da15.png)

![screenshot-ci foo redhat com-1337-2019 06 12-14-18-57](https://user-images.githubusercontent.com/22619452/59351116-f249c680-8d1d-11e9-867b-1b02e8e19619.png)
