### PR TITLE
Added copy portfolio modal.

### DIFF
--- a/src/helpers/portfolio/portfolio-helper.js
+++ b/src/helpers/portfolio/portfolio-helper.js
@@ -103,3 +103,5 @@ export function fetchPortfolioByName(name = '') {
 export const restorePortfolioItems = restoreData =>
   Promise.all(restoreData.map(({ portfolioItemId, restoreKey }) =>
     portfolioItemApi.portfolioItemsPortfolioItemIdUndeletePost(portfolioItemId, { restore_key: restoreKey })));
+
+export const copyPortfolio = portfolioId => portfolioApi.postCopyPortfolio(portfolioId);

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -163,3 +163,15 @@ export const removeProductsFromPortfolio = (portfolioItems, portfolioName) => (d
   .catch(err => dispatch({ type: `${ActionTypes.REMOVE_PORTFOLIO_ITEMS}_REJECTED`, payload: err }));
 };
 
+export const copyPortfolio = id => dispatch => {
+  dispatch({ type: 'COPY_PORTFOLIO_PENDING' });
+  return PortfolioHelper.copyPortfolio(id)
+  .then(portfolio => {
+    console.log('portfolio: ', portfolio);
+    dispatch({ type: 'COPY_PORTFOLIO_FULFILLED' });
+    dispatch({ type: ADD_NOTIFICATION, payload: { variant: 'success', title: 'You have successfully copied a portfolio' }});
+    return portfolio;
+  })
+  .catch(err => dispatch({ type: 'COPY_PORTFOLIO_REJECTED', payload: err }));
+};
+

--- a/src/smart-components/portfolio/portfolio.js
+++ b/src/smart-components/portfolio/portfolio.js
@@ -18,8 +18,14 @@ import { filterServiceOffering } from '../../helpers/shared/helpers';
 import PortfolioItemDetail from './portfolio-item-detail/portfolio-item-detail';
 import createPortfolioToolbarSchema from '../../toolbar/schemas/portfolio-toolbar.schema';
 import ContentGalleryEmptyState, { EmptyStatePrimaryAction } from '../../presentational-components/shared/content-gallery-empty-state';
-import { fetchSelectedPortfolio, fetchPortfolioItemsWithPortfolio, removeProductsFromPortfolio } from '../../redux/actions/portfolio-actions';
 import createRemoveProductsSchema from '../../toolbar/schemas/remove-products-toolbar.schema';
+import {
+  copyPortfolio,
+  fetchPortfolios,
+  fetchSelectedPortfolio,
+  removeProductsFromPortfolio,
+  fetchPortfolioItemsWithPortfolio
+} from '../../redux/actions/portfolio-actions';
 
 class Portfolio extends Component {
   state = {
@@ -27,7 +33,8 @@ class Portfolio extends Component {
     filteredItems: [],
     selectedItems: [],
     filterValue: '',
-    isKebabOpen: false
+    isKebabOpen: false,
+    copyInProgress: false
   };
 
   handleKebabOpen = isKebabOpen => this.setState({ isKebabOpen });
@@ -47,6 +54,15 @@ class Portfolio extends Component {
       this.fetchData(this.props.match.params.id);
       scrollToTop();
     }
+  }
+
+  copyPortfolio = () => {
+    this.setState({ copyInProgress: true });
+    return this.props.copyPortfolio(this.props.match.params.id)
+    .then(({ id }) => this.props.history.push(`/portfolios/detail/${id}`))
+    .then(() => this.setState({ copyInProgress: false }))
+    .then(() => this.props.fetchPortfolios())
+    .catch(() => this.setState({ copyInProgress: false }));
   }
 
   removeProducts = () => {
@@ -106,9 +122,11 @@ class Portfolio extends Component {
         editPortfolioRoute,
         sharePortfolioRoute,
         removePortfolioRoute,
+        copyPortfolio: this.copyPortfolio,
         isLoading: this.props.isLoading,
         setKebabOpen: this.handleKebabOpen,
-        isKebabOpen: this.state.isKebabOpen
+        isKebabOpen: this.state.isKebabOpen,
+        copyInProgress: this.state.copyInProgress
       }) } />
       <Route exact path="/portfolios/detail/:id/edit-portfolio" component={ AddPortfolioModal } />
       <Route exact path="/portfolios/detail/:id/remove-portfolio" component={ RemovePortfolioModal } />
@@ -192,7 +210,9 @@ const mapStateToProps = ({ portfolioReducer: { selectedPortfolio, portfolioItems
 const mapDispatchToProps = dispatch => bindActionCreators({
   fetchPortfolioItemsWithPortfolio,
   fetchSelectedPortfolio,
-  removeProductsFromPortfolio
+  removeProductsFromPortfolio,
+  fetchPortfolios,
+  copyPortfolio
 }, dispatch);
 
 Portfolio.propTypes = {
@@ -200,6 +220,7 @@ Portfolio.propTypes = {
   fetchPortfolioItemsWithPortfolio: PropTypes.func,
   fetchSelectedPortfolio: PropTypes.func,
   match: PropTypes.object,
+  fetchPortfolios: PropTypes.func.isRequired,
   portfolio: PropTypes.shape({
     name: PropTypes.string,
     id: PropTypes.string.isRequired
@@ -207,7 +228,8 @@ Portfolio.propTypes = {
   location: PropTypes.object,
   history: PropTypes.object,
   portfolioItems: PropTypes.array,
-  removeProductsFromPortfolio: PropTypes.func.isRequired
+  removeProductsFromPortfolio: PropTypes.func.isRequired,
+  copyPortfolio: PropTypes.func.isRequired
 };
 
 Portfolio.defaultProps = {

--- a/src/toolbar/schemas/portfolio-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolio-toolbar.schema.js
@@ -9,14 +9,18 @@ import { createSingleItemGroup, createLinkButton } from '../helpers';
 /**
  * Cannot be anonymous function. Requires Component.diplayName to work with PF4 refs
  */
-const PortfolioActionsToolbar = ({ setKebabOpen, isKebabOpen, removePortfolioRoute }) => (
+const PortfolioActionsToolbar = ({ setKebabOpen, isKebabOpen, removePortfolioRoute, copyInProgress, copyPortfolio }) => (
   <Dropdown
     onSelect={ () => setKebabOpen(false) }
     position={ DropdownPosition.right }
-    toggle={ <KebabToggle onToggle={ setKebabOpen }/> }
+    toggle={ <KebabToggle onToggle={ setKebabOpen } isDisabled={ copyInProgress }/> }
     isOpen={ isKebabOpen }
+    isDisabled
     isPlain
     dropdownItems={ [
+      <DropdownItem component="button" aria-label="Copy Portfolio" key="copy-portfolio" onClick={ copyPortfolio }>
+        Copy
+      </DropdownItem>,
       <DropdownItem aria-label="Remove Portfolio" key="delete-portfolio">
         <Link to={ removePortfolioRoute } role="link" className="pf-c-dropdown__menu-item destructive-color">
           Delete
@@ -29,16 +33,20 @@ const PortfolioActionsToolbar = ({ setKebabOpen, isKebabOpen, removePortfolioRou
 PortfolioActionsToolbar.propTypes = {
   setKebabOpen: PropTypes.func.isRequired,
   isKebabOpen: PropTypes.bool,
-  removePortfolioRoute: PropTypes.string.isRequired
+  removePortfolioRoute: PropTypes.string.isRequired,
+  copyPortfolio: PropTypes.func.isRequired,
+  copyInProgress: PropTypes.bool
 };
 
 const createPortfolioToolbarSchema = ({
   title,
   addProductsRoute,
+  copyPortfolio,
   sharePortfolioRoute,
   editPortfolioRoute,
   removePortfolioRoute,
   removeProductsRoute,
+  copyInProgress,
   isKebabOpen,
   setKebabOpen,
   isLoading,
@@ -64,18 +72,22 @@ const createPortfolioToolbarSchema = ({
             to: sharePortfolioRoute,
             variant: 'secondary',
             title: 'Share',
+            isDisabled: copyInProgress,
             key: 'portfolio-share-button'
           }),
           createLinkButton({
             to: editPortfolioRoute,
             variant: 'link',
+            isDisabled: copyInProgress,
             title: 'Edit',
             key: 'portfolio-edit-button'
           }), {
             component: PortfolioActionsToolbar,
             removePortfolioRoute,
+            copyPortfolio,
             isKebabOpen,
             setKebabOpen,
+            copyInProgress,
             key: 'portfolio-actions-dropdown'
           }]
       }]
@@ -97,7 +109,7 @@ const createPortfolioToolbarSchema = ({
           key: 'portfolio-items-add-group',
           ...createLinkButton({
             to: addProductsRoute,
-            isDisabled: isLoading,
+            isDisabled: isLoading || copyInProgress,
             variant: 'primary',
             title: 'Add products',
             key: 'add-products-button'
@@ -108,7 +120,7 @@ const createPortfolioToolbarSchema = ({
           key: 'portfolio-items-add-group',
           ...createLinkButton({
             to: removeProductsRoute,
-            isDisabled: isLoading,
+            isDisabled: isLoading || copyInProgress,
             variant: 'link',
             className: 'destructive-color',
             title: 'Remove products',


### PR DESCRIPTION
### Changes
- adds copy portfolio modal

Currently the copy portfolio endpoint does not accept `name` or `share with the same groups attributes` as is showed on mocks: https://redhat.invisionapp.com/d/main#/console/16104390/365986228/preview

![copy-portfolio](https://user-images.githubusercontent.com/22619452/59424352-1bc52980-8dd4-11e9-8cc8-2617cbdbdb62.gif)
