### PR TITLE
Fix portfolio card header overflow.

### DIFF
--- a/src/presentational-components/portfolio/portfolio-card-header.js
+++ b/src/presentational-components/portfolio/portfolio-card-header.js
@@ -6,9 +6,9 @@ import './portfolio-card.scss';
 
 const PortfolioCardHeader = ({ portfolioName, headerActions }) => (
   <Level>
-    <LevelItem>
+    <LevelItem className="portfolio-card-header-title">
       <TextContent>
-        <Text className="elipsis-text-overflow pf-u-mb-0" component={ TextVariants.h3 }>{ portfolioName }</Text>
+        <Text title={ portfolioName } className="elipsis-text-overflow pf-u-mb-0" component={ TextVariants.h3 }>{ portfolioName }</Text>
       </TextContent>
     </LevelItem>
     <LevelItem onClick={ event => event.preventDefault() }>

--- a/src/presentational-components/portfolio/portfolio-card.scss
+++ b/src/presentational-components/portfolio/portfolio-card.scss
@@ -12,3 +12,7 @@
   padding: 8px 24px;
 }
 
+.portfolio-card-header-title {
+  max-width: calc(100% - 44px)
+}
+

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-card-header.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-card-header.test.js.snap
@@ -5,13 +5,16 @@ exports[`<PortfolioCardHeader /> should render correctly 1`] = `
   className=""
   gutter={null}
 >
-  <LevelItem>
+  <LevelItem
+    className="portfolio-card-header-title"
+  >
     <TextContent
       className=""
     >
       <Text
         className="elipsis-text-overflow pf-u-mb-0"
         component="h3"
+        title="foo"
       >
         foo
       </Text>


### PR DESCRIPTION
If the portfolio title was too long the text was overflowing the card and button actions were pushed to next line.

### Before => After
![screenshot-ci foo redhat com-1337-2019 06 14-11-02-06](https://user-images.githubusercontent.com/22619452/59497765-568e9680-8e94-11e9-8093-59e33966d1fa.png)

Thanks @lgalis for noticing this