### PR TITLE
Added copy portfolio item feature.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -900,21 +900,22 @@
       }
     },
     "@data-driven-forms/pf4-component-mapper": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-1.9.11.tgz",
-      "integrity": "sha512-/4AcxhcdetGxZK+gpYVv3RnAgyy1lYdsyB80ddKEN5PZ5SBZh6D1+3B+5JEfqych+86SNBSlV60SPOUJThwOgQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-1.11.0.tgz",
+      "integrity": "sha512-IZzmijukSHbRI7X6Pj+jRjUHTOtzBsMStuWgDhgD0WEVwe+WhmFTuRpgmXdDbdKWoOha4BY2CyvMNTNrk/OiRQ==",
       "requires": {
         "@patternfly/patternfly-next": "^1.0.87"
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.9.11.tgz",
-      "integrity": "sha512-oORV3BCUVszlqhi3oe8VFCIZHImI7InBm8qJy0KMnohie2IMwYTXwDSSzB7pD92NsI3sOf1PzcP/3l9NSZRPHw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.11.0.tgz",
+      "integrity": "sha512-d6P0dXes7YCk4wS6uAK4N7cqsmXMFrHHrG07n4sTfUzCAoFa/IWaqtUvsFcxBUMos3bdQ3VXZXYQA0KiKDKh1g==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.1.0",
         "final-form": "^4.12.0",
         "final-form-arrays": "^1.1.0",
+        "final-form-focus": "^1.1.2",
         "react-final-form": "^4.1.0",
         "react-final-form-arrays": "2.0.1"
       }
@@ -5850,9 +5851,9 @@
       }
     },
     "final-form": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.12.0.tgz",
-      "integrity": "sha512-z1fSzDNmIBlDjRMaluM3WgDbcwCFpPm7mvopplgXGMRS49MXR+1n//lteLwPURdGQNOZhWm3GwiEJanEHCItww==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.15.0.tgz",
+      "integrity": "sha512-A7pvzFAZ/mswLfU4pMKnB+otx3ttv8dO6/X+gWqhUSP+EpNsMenY88PHuGNJ9bIkhYcwF1ErXB8b2E2EMHKBLg==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -5861,6 +5862,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-1.1.2.tgz",
       "integrity": "sha512-Pmq3MXI9zbSsY7WZ2eodWQAHpsw2/i5YkagzcCgqzRcSSHB8BD3yWi7YPSGTPXuG0ixcQe9VAYpQ+UEWcqf4zg=="
+    },
+    "final-form-focus": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/final-form-focus/-/final-form-focus-1.1.2.tgz",
+      "integrity": "sha512-Gd+Bd2Ll7ijo3/sd6kJ/bwLkhc2bUJPxTON6fIqee/008EJpACWhT+zoWCm9q6NcfMcWRS+Sp5ikRX8iqdXeGQ=="
     },
     "find-cache-dir": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1335,17 +1335,17 @@
       }
     },
     "@redhat-cloud-services/catalog-client": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/catalog-client/-/catalog-client-1.0.14.tgz",
-      "integrity": "sha512-pTxxXOrc1JC/IsdHQSKmU7m/wPass5ukJeOy0/8/g1laqRy3Iq02Tu6prHte/e4DhN7ZbSQ/+Ya4NaXCtxcHoQ==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/catalog-client/-/catalog-client-1.0.20.tgz",
+      "integrity": "sha512-1tMUuvkA7Sg9j8rznjGT/X/DsENd6xpnlNOmG3/l8ysB/E4xiLZ5a2uxCJWgMlCLkwGKx7adO1UrwyD70z5eFg==",
       "requires": {
-        "axios": "^0.18.0"
+        "axios": "^0.19.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.18.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
           "requires": {
             "follow-redirects": "1.5.10",
             "is-buffer": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@data-driven-forms/pf4-component-mapper": "^1.9.11",
-    "@data-driven-forms/react-form-renderer": "^1.9.11",
+    "@data-driven-forms/pf4-component-mapper": "^1.11.0",
+    "@data-driven-forms/react-form-renderer": "^1.11.0",
     "@manageiq/topological_inventory": "~1.1.0",
     "@patternfly/react-core": "3.16.10",
     "@patternfly/react-icons": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@patternfly/react-core": "3.16.10",
     "@patternfly/react-icons": "3.7.2",
     "@redhat-cloud-services/approval-client": "^1.0.4",
-    "@redhat-cloud-services/catalog-client": "^1.0.14",
+    "@redhat-cloud-services/catalog-client": "^1.0.20",
     "@redhat-cloud-services/frontend-components": "0.0.7",
     "@redhat-cloud-services/frontend-components-notifications": "0.0.5",
     "@redhat-cloud-services/frontend-components-utilities": "0.0.7",

--- a/src/helpers/portfolio/portfolio-helper.js
+++ b/src/helpers/portfolio/portfolio-helper.js
@@ -105,3 +105,5 @@ export const restorePortfolioItems = restoreData =>
     portfolioItemApi.portfolioItemsPortfolioItemIdUndeletePost(portfolioItemId, { restore_key: restoreKey })));
 
 export const copyPortfolio = portfolioId => portfolioApi.postCopyPortfolio(portfolioId);
+
+export const copyPortfolioItem = (portfolioItemId, copyObject = {}) => portfolioItemApi.postCopyPortfolioItem(portfolioItemId, copyObject);

--- a/src/presentational-components/shared/pf4-select-wrapper.js
+++ b/src/presentational-components/shared/pf4-select-wrapper.js
@@ -20,11 +20,24 @@ const Select = ({
   isDisabled,
   FieldProvider,
   isRequired,
+  formOptions: { change },
   ...rest
 }) => (
-  <FormSelect { ...input } { ...rest } isDisabled={ isDisabled || isReadOnly }>
+  <FormSelect { ...input } { ...rest }
+    onChange={ (value, ...args) => {
+      if (rest.onChange) {
+        rest.onChange(value);
+        change(input.name, [ value, ...args ]);
+      } else {
+        input.onChange(value, ...args);
+      }
+    } } isDisabled={ isDisabled || isReadOnly }>
     { createOptions(options, input.value, isRequired).map((props) => (
-      <FormSelectOption key={ props.value || props.label } { ...props } label={ props.label.toString() }/> // eslint-disable-line react/prop-types
+      <FormSelectOption
+        key={ props.value || props.label } // eslint-disable-line react/prop-types
+        { ...props }
+        label={ props.label.toString() }
+      />
     )) }
   </FormSelect>
 );
@@ -38,7 +51,14 @@ Select.propTypes = {
   isReadOnly: PropTypes.bool,
   isDisabled: PropTypes.bool,
   isRequired: PropTypes.bool,
-  FieldProvider: PropTypes.any
+  FieldProvider: PropTypes.any,
+  formOptions: PropTypes.shape({
+    change: PropTypes.func
+  })
+};
+
+Select.defaultProps = {
+  formOptions: {}
 };
 
 const Pf4SelectWrapper = ({
@@ -69,7 +89,7 @@ const Pf4SelectWrapper = ({
       helperTextInvalid={ meta.error }
     >
       { description && <TextContent><Text component={ TextVariants.small }>{ description }</Text></TextContent> }
-      <Select id={ id || name } label={ label } isValid={ !showError } isRequired={ isRequired } { ...rest }/>
+      <Select formOptions={ formOptions } id={ id || name } label={ label } isValid={ !showError } isRequired={ isRequired } { ...rest }/>
     </FormGroup>
   );
 };

--- a/src/presentational-components/shared/pf4-select-wrapper.js
+++ b/src/presentational-components/shared/pf4-select-wrapper.js
@@ -27,7 +27,7 @@ const Select = ({
     onChange={ (value, ...args) => {
       if (rest.onChange) {
         rest.onChange(value);
-        change(input.name, [ value, ...args ]);
+        change(input.name, value);
       } else {
         input.onChange(value, ...args);
       }

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -176,3 +176,17 @@ export const copyPortfolio = id => dispatch => {
   .catch(err => dispatch({ type: 'COPY_PORTFOLIO_REJECTED', payload: err }));
 };
 
+export const copyPortfolioItem = (portfolioItemId, copyObject, newPortfolio) => dispatch => {
+  return PortfolioHelper.copyPortfolioItem(portfolioItemId, copyObject)
+  .then(data => {
+    dispatch({ type: ADD_NOTIFICATION, payload: {
+      variant: 'success',
+      title: 'You have successfully copied a product',
+      description: `${data.display_name} has been copied into ${newPortfolio.name}`,
+      dismissable: true
+    }});
+    return data;
+  })
+  .catch(err => dispatch({ type: 'COPY_PORTFOLIO_ITEM_REJECTED', payload: err }));
+};
+

--- a/src/smart-components/common/form-renderer.js
+++ b/src/smart-components/common/form-renderer.js
@@ -7,7 +7,7 @@ import Pf4SelectWrapper from '../../presentational-components/shared/pf4-select-
 const buttonPositioning = {
   default: {},
   modal: {
-    buttonOrder: [ 'cancel', 'reset', 'save' ],
+    buttonOrder: [ 'save', 'cancel', 'reset' ],
     buttonClassName: 'modal-form-right-align'
   }
 };
@@ -17,7 +17,7 @@ const FormRenderer = ({ componentMapper, formContainer, ...rest }) => (
     <ReactFormRender
       formFieldsMapper={ {
         ...formFieldsMapper,
-        componentMapper,
+        ...componentMapper,
         [componentTypes.SELECT]: Pf4SelectWrapper
       } }
       layoutMapper={ layoutMapper }

--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -14,7 +14,7 @@ import { componentTypes } from '@data-driven-forms/react-form-renderer';
 
 import FormRenderer from '../../common/form-renderer';
 import { getPortfolioItemApi } from '../../../helpers/shared/user-login';
-import { copyPortfolioItem } from '../../../redux/actions/portfolio-actions';
+import { copyPortfolioItem, fetchPortfolioItemsWithPortfolio } from '../../../redux/actions/portfolio-actions';
 
 const copySchema = (portfolios, portfolioName, portfolioChange, nameFetching) => ({
   fields: [{
@@ -51,7 +51,8 @@ const CopyPortfolioItemModal = ({
   portfolioId,
   portfolioItemId,
   closeUrl,
-  history: { push }
+  history: { push },
+  fetchPortfolioItemsWithPortfolio
 }) => {
   const [ submitting, setSubmitting ] = useState(false);
   const [ name, setName ] = useState();
@@ -64,6 +65,10 @@ const CopyPortfolioItemModal = ({
     setSubmitting(true);
     copyPortfolioItem(portfolioItemId, values, portfolios.find(({ id }) => id === values.portfolio_id))
     .then(({ id }) => push(`/portfolios/detail/${values.portfolio_id}/product/${id}`))
+    .then(() => {
+      console.log('Ids: ', values.portfolio_id === portfolioId);
+      return values.portfolio_id === portfolioId && fetchPortfolioItemsWithPortfolio(portfolioId);
+    })
     .catch(() => setSubmitting(false));
   };
 
@@ -100,10 +105,10 @@ CopyPortfolioItemModal.propTypes = {
     push: PropTypes.func.isRequired
   }).isRequired,
   portfolioId: PropTypes.string.isRequired,
-  copyName: PropTypes.string.isRequired,
   portfolios: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   copyPortfolioItem: PropTypes.func.isRequired,
-  portfolioItemId: PropTypes.string.isRequired
+  portfolioItemId: PropTypes.string.isRequired,
+  fetchPortfolioItemsWithPortfolio: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({ portfolioReducer: { portfolios }}) => ({
@@ -111,7 +116,8 @@ const mapStateToProps = ({ portfolioReducer: { portfolios }}) => ({
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-  copyPortfolioItem
+  copyPortfolioItem,
+  fetchPortfolioItemsWithPortfolio
 }, dispatch);
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CopyPortfolioItemModal));

--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { withRouter } from 'react-router-dom';
+import {
+  FormGroup,
+  Modal,
+  TextContent,
+  Text,
+  TextVariants
+} from '@patternfly/react-core';
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+
+import FormRenderer from '../../common/form-renderer';
+import { copyPortfolioItem } from '../../../redux/actions/portfolio-actions';
+
+const copySchema = (portfolios, portfolioName) => ({
+  fields: [{
+    component: 'value-only',
+    name: 'portfolio_item_name',
+    label: 'Name',
+    value: portfolioName
+  }, {
+    component: componentTypes.SELECT,
+    name: 'portfolio_id',
+    label: 'Portfolio',
+    isRequired: true,
+    options: portfolios.map(({ id, display_name, name }) => ({ label: display_name || name, value: id }))
+  }]
+});
+
+const ValueOnly = ({ name, label, value }) => (
+  <FormGroup label={ label } fieldId={ name }>
+    <TextContent><Text component={ TextVariants.h6 }>{ value }</Text></TextContent>
+  </FormGroup>
+);
+
+ValueOnly.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+const CopyPortfolioItemModal = ({
+  copyPortfolioItem,
+  portfolios,
+  copyName,
+  portfolioId,
+  portfolioItemId,
+  closeUrl,
+  history: { push }
+}) => {
+  const [ submitting, setSubmitting ] = useState(false);
+  const onSubmit = values => {
+    setSubmitting(true);
+    copyPortfolioItem(portfolioItemId, values, portfolios.find(({ id }) => id === values.portfolio_id))
+    .then(({ id }) => push(`/portfolios/detail/${values.portfolio_id}/product/${id}`))
+    .catch(() => setSubmitting(false));
+  };
+
+  return (
+    <Modal
+      isOpen
+      title="Copy product"
+      onClose={ () => push(closeUrl) }
+      isSmall
+    >
+      <FormRenderer
+        initialValues={ { portfolio_id: portfolioId, portfolio_item_name: copyName } }
+        schema={ copySchema(portfolios, copyName) }
+        onSubmit={ onSubmit }
+        onCancel={ () => push(closeUrl) }
+        componentMapper={ { 'value-only': ValueOnly } }
+        buttonsLabels={ { submitLabel: 'Save' } }
+        disableSubmit={ submitting ? [ 'pristine', 'diry' ] : [] }
+      />
+    </Modal>
+  );};
+
+CopyPortfolioItemModal.propTypes = {
+  closeUrl: PropTypes.string.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  }).isRequired,
+  portfolioId: PropTypes.string.isRequired,
+  copyName: PropTypes.string.isRequired,
+  portfolios: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  copyPortfolioItem: PropTypes.func.isRequired,
+  portfolioItemId: PropTypes.string.isRequired
+};
+
+const mapStateToProps = ({
+  portfolioReducer: { portfolios, portfolioItem: { display_name }}
+}) => ({
+  copyName: `Copy of ${display_name}`,
+  portfolios
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  copyPortfolioItem
+}, dispatch);
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CopyPortfolioItemModal));

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { Dropdown, DropdownItem, DropdownPosition, KebabToggle, LevelItem } from '@patternfly/react-core';
 import ButtonWithSpinner from '../../../presentational-components/shared/button-with-spinner';
 
-const DetailToolbarActions = ({ orderUrl, editUrl, isOpen, setOpen, isFetching }) => ( // eslint-disable-line no-unused-vars
+const DetailToolbarActions = ({ copyUrl, orderUrl, editUrl, isOpen, setOpen, isFetching }) => ( // eslint-disable-line no-unused-vars
   <Fragment>
     <LevelItem>
       <Link disabled={ isFetching } to={ orderUrl }>
@@ -23,7 +23,12 @@ const DetailToolbarActions = ({ orderUrl, editUrl, isOpen, setOpen, isFetching }
           dropdownItems={ [
             <DropdownItem aria-label="Edit Portfolio" key="edit-portfolio">
               <Link to={ editUrl } role="link" className="pf-c-dropdown__menu-item">
-                   Edit
+                Edit
+              </Link>
+            </DropdownItem>,
+            <DropdownItem aria-label="Copy Portfolio" key="copy-portfolio">
+              <Link to={ copyUrl } role="link" className="pf-c-dropdown__menu-item">
+                Copy
               </Link>
             </DropdownItem>
           ] }
@@ -36,6 +41,7 @@ const DetailToolbarActions = ({ orderUrl, editUrl, isOpen, setOpen, isFetching }
 DetailToolbarActions.propTypes = {
   orderUrl: PropTypes.string.isRequired,
   editUrl: PropTypes.string.isRequired,
+  copyUrl: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   setOpen: PropTypes.func.isRequired,
   isFetching: PropTypes.bool

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -39,6 +39,7 @@ const PortfolioItemDetailToolbar = ({
                 setOpen={ setOpen }
                 orderUrl={ `${url}/order` }
                 editUrl={ `${url}/edit` }
+                copyUrl={ `${url}/copy` }
                 isFetching={ isFetching }
                 { ...args }
               />) }/>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -10,6 +10,7 @@ import OrderModal from '../../common/order-modal';
 import ItemDetailInfoBar from './item-detail-info-bar';
 import { allowNull } from '../../../helpers/shared/helpers';
 import ItemDetailDescription from './item-detail-description';
+import CopyPortfolioItemModal from './copy-portfolio-item-modal';
 import { fetchPlatforms } from '../../../redux/actions/platform-actions';
 import { fetchWorkflows } from '../../../redux/actions/approval-actions';
 import PortfolioItemDetailToolbar from './portfolio-item-detail-toolbar';
@@ -63,6 +64,12 @@ const PortfolioItemDetail = ({
   return (
     <Section style={ { backgroundColor: 'white', minHeight: '100%' } }>
       <Route path={ `${url}/order` } render={ props => <OrderModal { ...props } closeUrl={ url } serviceData={ product }/> }/>
+      <Route
+        path={ `${url}/copy` }
+        render={ props => (
+          <CopyPortfolioItemModal { ...props }  portfolioItemId={ product.id } portfolioId={ portfolio.id } closeUrl={ url }/>
+        ) }
+      />
       <PortfolioItemDetailToolbar
         url={ url }
         isOpen={ isOpen }

--- a/src/test/presentational-components/shared/__snapshots__/pf4-select-wrapper.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/pf4-select-wrapper.test.js.snap
@@ -3,6 +3,11 @@
 exports[`<Pf4SelectWrapper /> should render correctly 1`] = `
 <Pf4SelectWrapper
   FieldProvider={[Function]}
+  formOptions={
+    Object {
+      "change": [MockFunction],
+    }
+  }
   id="bazz"
   input={
     Object {
@@ -33,6 +38,11 @@ exports[`<Pf4SelectWrapper /> should render correctly 1`] = `
     >
       <Select
         FieldProvider={[Function]}
+        formOptions={
+          Object {
+            "change": [MockFunction],
+          }
+        }
         id="bazz"
         input={
           Object {
@@ -59,7 +69,7 @@ exports[`<Pf4SelectWrapper /> should render correctly 1`] = `
           isValid={true}
           name="bazz"
           onBlur={[Function]}
-          onChange={[MockFunction]}
+          onChange={[Function]}
           onFocus={[Function]}
           value=""
         >
@@ -116,6 +126,11 @@ exports[`<Pf4SelectWrapper /> should render correctly 1`] = `
 exports[`<Pf4SelectWrapper /> should render correctly in error state 1`] = `
 <Pf4SelectWrapper
   FieldProvider={[Function]}
+  formOptions={
+    Object {
+      "change": [MockFunction],
+    }
+  }
   id="bazz"
   input={
     Object {
@@ -152,6 +167,11 @@ exports[`<Pf4SelectWrapper /> should render correctly in error state 1`] = `
     >
       <Select
         FieldProvider={[Function]}
+        formOptions={
+          Object {
+            "change": [MockFunction],
+          }
+        }
         id="bazz"
         input={
           Object {
@@ -178,7 +198,7 @@ exports[`<Pf4SelectWrapper /> should render correctly in error state 1`] = `
           isValid={false}
           name="bazz"
           onBlur={[Function]}
-          onChange={[MockFunction]}
+          onChange={[Function]}
           onFocus={[Function]}
           value=""
         >
@@ -243,6 +263,11 @@ exports[`<Pf4SelectWrapper /> should render correctly with description 1`] = `
 <Pf4SelectWrapper
   FieldProvider={[Function]}
   description="description"
+  formOptions={
+    Object {
+      "change": [MockFunction],
+    }
+  }
   id="bazz"
   input={
     Object {
@@ -292,6 +317,11 @@ exports[`<Pf4SelectWrapper /> should render correctly with description 1`] = `
       </TextContent>
       <Select
         FieldProvider={[Function]}
+        formOptions={
+          Object {
+            "change": [MockFunction],
+          }
+        }
         id="bazz"
         input={
           Object {
@@ -318,7 +348,7 @@ exports[`<Pf4SelectWrapper /> should render correctly with description 1`] = `
           isValid={true}
           name="bazz"
           onBlur={[Function]}
-          onChange={[MockFunction]}
+          onChange={[Function]}
           onFocus={[Function]}
           value=""
         >

--- a/src/test/presentational-components/shared/pf4-select-wrapper.test.js
+++ b/src/test/presentational-components/shared/pf4-select-wrapper.test.js
@@ -19,6 +19,9 @@ describe('<Pf4SelectWrapper />', () => {
         label: 'Foo',
         value: 'bar'
       }],
+      formOptions: {
+        change: jest.fn()
+      },
       FieldProvider: () => <div />
     };
   });

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -88,6 +88,21 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                 Edit
               </Link>
             </Item>,
+            <Item
+              aria-label="Copy Portfolio"
+              className=""
+              component="a"
+              href="#"
+              isDisabled={false}
+              isHovered={false}
+            >
+              <Link
+                className="pf-c-dropdown__menu-item"
+                role="link"
+              >
+                Copy
+              </Link>
+            </Item>,
           ]
         }
         isOpen={false}

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-description.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-description.test.js.snap
@@ -396,6 +396,7 @@ exports[`<ItemDetailDescription /> should render correctly in edit variant 1`] =
                     Approval workflow
                   </label>
                   <Select
+                    formOptions={Object {}}
                     id="change-workflow"
                     input={
                       Object {


### PR DESCRIPTION
@syncrou @gmcculloug I have a question about the new portfolio name. UI renders the `display_name` attribute of portfolio item because that is the human readable equivalent of `name` but the copy endpoint changes the `name` attribute so the `display_name` is unchanged. 

I belive the `display_name` should be modified instead. Any thoughs?
(endpoint PR: https://github.com/ManageIQ/catalog-api/pull/289)

### Changes
- added copy portfolio item modal
- mocks: https://docs.google.com/presentation/d/1Z0Jd5JQa1eavch_ZbTJ8YkDjRZpu6twyece1T-k8xOw/edit#slide=id.g5b73dafedf_0_47
![copy-portfolio-item](https://user-images.githubusercontent.com/22619452/59670264-f06b8180-91bb-11e9-95d5-a7641d81c3aa.gif)
