### PR TITLE
Added disabled state to portfolio items in content gallery.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -188,6 +188,20 @@
   }
 }
 
+.portfolio-item-progress {
+  position: relative;
+  height: 330px;
+  .content-gallery-card {
+    position: absolute;
+    width: 100%;
+    &.progress-overlay {
+      background-color: rgba(210, 210, 210, .5);
+      z-index: 1;
+      cursor: progress;
+    }
+  }
+}
+
 //pf-4 fixes
 /**
 * non working pf display modifier: https://www.patternfly.org/v4/documentation/core/utilities/display#display-block

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -116,6 +116,7 @@ export const undoRemoveProductsFromPortfolio = (restoreData, portfolioId) => dis
   return PortfolioHelper.restorePortfolioItems(restoreData)
   .then(() => dispatch({ type: `${ActionTypes.RESTORE_PORTFOLIO_ITEMS}_FULFILLED` }))
   .then(() => dispatch({ type: CLEAR_NOTIFICATIONS }))
+  .then(() => dispatch(fetchPortfolioItemsWithPortfolio(portfolioId)))
   .then(() => dispatch({
     type: ADD_NOTIFICATION,
     payload: {
@@ -124,7 +125,6 @@ export const undoRemoveProductsFromPortfolio = (restoreData, portfolioId) => dis
       title: 'Products have been restored'
     }
   }))
-  .then(() => dispatch(fetchPortfolioItemsWithPortfolio(portfolioId)))
   .catch(err => dispatch({
     type: `${ActionTypes.RESTORE_PORTFOLIO_ITEMS}_REJECTED`,
     payload: err
@@ -136,7 +136,9 @@ export const removeProductsFromPortfolio = (portfolioItems, portfolioName) => (d
     type: `${ActionTypes.REMOVE_PORTFOLIO_ITEMS}_PENDING`
   });
   const { portfolioReducer: { selectedPortfolio: { id: portfolioId }}} = getState();
-  return PortfolioHelper.removePortfolioItems(portfolioItems).then(data => {
+  return PortfolioHelper.removePortfolioItems(portfolioItems)
+  .then(data => dispatch(fetchPortfolioItemsWithPortfolio(portfolioId)).then(() => data))
+  .then(data => {
     return dispatch({
       type: ADD_NOTIFICATION,
       payload: {
@@ -167,7 +169,6 @@ export const copyPortfolio = id => dispatch => {
   dispatch({ type: 'COPY_PORTFOLIO_PENDING' });
   return PortfolioHelper.copyPortfolio(id)
   .then(portfolio => {
-    console.log('portfolio: ', portfolio);
     dispatch({ type: 'COPY_PORTFOLIO_FULFILLED' });
     dispatch({ type: ADD_NOTIFICATION, payload: { variant: 'success', title: 'You have successfully copied a portfolio' }});
     return portfolio;

--- a/src/redux/reducers/portfolio-reducer.js
+++ b/src/redux/reducers/portfolio-reducer.js
@@ -7,7 +7,8 @@ import {
   FILTER_PORTFOLIO_ITEMS,
   SELECT_PORTFOLIO_ITEM,
   UPDATE_PORTFOLIO,
-  SET_LOADING_STATE
+  SET_LOADING_STATE,
+  REMOVE_PORTFOLIO_ITEMS
 } from '../action-types';
 
 // Initial State
@@ -42,5 +43,6 @@ export default {
   [`${SELECT_PORTFOLIO_ITEM}_FULFILLED`]: setPortfolioItem,
   [SELECT_PORTFOLIO_ITEM]: setPortfolioItem,
   [`${UPDATE_PORTFOLIO}_FULFILLED`]: selectPortfolio,
-  [SET_LOADING_STATE]: setLoadingState
+  [SET_LOADING_STATE]: setLoadingState,
+  [`${REMOVE_PORTFOLIO_ITEMS}_PENDING`]: setLoadingState
 };

--- a/src/smart-components/portfolio/portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item.js
@@ -25,15 +25,21 @@ const PortfolioItem = props => {
       </CardFooter>
     </Fragment>
   );
+
   return (
     <GalleryItem>
-      <Card className="content-gallery-card">
-        { props.isSelectable ? renderCardContent() : (
-          <Link to={ props.orderUrl } className="card-link" >
-            { renderCardContent() }
-          </Link>
+      <div className={ `${props.removeInProgress && props.isSelected ? 'portfolio-item-progress' : ''} ` }>
+        { props.removeInProgress && props.isSelected && (
+          <Card className="content-gallery-card progress-overlay" />
         ) }
-      </Card>
+        <Card className="content-gallery-card">
+          { props.isSelectable ? renderCardContent() : (
+            <Link to={ props.orderUrl } className="card-link" >
+              { renderCardContent() }
+            </Link>
+          ) }
+        </Card>
+      </div>
     </GalleryItem>
   );};
 
@@ -47,7 +53,8 @@ PortfolioItem.propTypes = {
   isSelectable: PropTypes.bool,
   isSelected: PropTypes.bool,
   onSelect: PropTypes.func,
-  orderUrl: PropTypes.string.isRequired
+  orderUrl: PropTypes.string.isRequired,
+  removeInProgress: PropTypes.bool
 };
 
 export default PortfolioItem;

--- a/src/smart-components/portfolio/portfolio.js
+++ b/src/smart-components/portfolio/portfolio.js
@@ -34,7 +34,8 @@ class Portfolio extends Component {
     selectedItems: [],
     filterValue: '',
     isKebabOpen: false,
-    copyInProgress: false
+    copyInProgress: false,
+    removeInProgress: false
   };
 
   handleKebabOpen = isKebabOpen => this.setState({ isKebabOpen });
@@ -66,14 +67,11 @@ class Portfolio extends Component {
   }
 
   removeProducts = () => {
+    this.setState({ removeInProgress: true });
     this.props.history.goBack();
-
-    this.props.removeProductsFromPortfolio(this.state.selectedItems, this.props.portfolio.name).then(() => {
-      this.fetchData(this.props.match.params.id);
-      this.setState({
-        selectedItems: []
-      });
-    });
+    this.props.removeProductsFromPortfolio(this.state.selectedItems, this.props.portfolio.name)
+    .then(() => this.setState({ selectedItems: [], removeInProgress: false }))
+    .catch(() => this.setState({ removeInProgress: false }));
   };
 
   handleItemSelect = selectedItem =>
@@ -178,6 +176,7 @@ class Portfolio extends Component {
           onSelect={ this.handleItemSelect }
           isSelected={ this.state.selectedItems.includes(item.id) }
           orderUrl={ `${orderUrl}/${item.id}` }
+          removeInProgress={ this.state.removeInProgress }
         />
       )),
       isLoading: this.props.isLoading && this.props.portfolioItems.length === 0

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -237,6 +237,10 @@ describe('Portfolio actions', () => {
     const store = mockStore({ portfolioReducer: { selectedPortfolio: { id: '123' }}});
     const expectedActions = [{
       type: `${REMOVE_PORTFOLIO_ITEMS}_PENDING`
+    }, {
+      type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`
+    }, {
+      type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`
     },
     expect.objectContaining({ type: ADD_NOTIFICATION }), {
       type: `${REMOVE_PORTFOLIO_ITEMS}_FULFILLED`
@@ -245,6 +249,7 @@ describe('Portfolio actions', () => {
     apiClientMock.delete(CATALOG_API_BASE + '/portfolio_items/1', mockOnce({ body: { restore_key: 'restore-1' }}));
     apiClientMock.delete(CATALOG_API_BASE + '/portfolio_items/2', mockOnce({ body: { restore_key: 'restore-2' }}));
     apiClientMock.delete(CATALOG_API_BASE + '/portfolio_items/3', mockOnce({ body: { restore_key: 'restore-3' }}));
+    apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items`, mockOnce({ body: []}));
 
     return store.dispatch(removeProductsFromPortfolio([ '1', '2', '3' ], 'Foo portfolio'))
     .then(() => expect(store.getActions()).toEqual(expectedActions));
@@ -275,13 +280,12 @@ describe('Portfolio actions', () => {
     }, {
       type: `${RESTORE_PORTFOLIO_ITEMS}_FULFILLED`
     },
-    expect.objectContaining({ type: CLEAR_NOTIFICATIONS }),
-    expect.objectContaining({ type: ADD_NOTIFICATION }), {
+    expect.objectContaining({ type: CLEAR_NOTIFICATIONS }), {
       type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`
     }, {
       type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
       payload: []
-    }];
+    }, expect.objectContaining({ type: ADD_NOTIFICATION }) ];
 
     apiClientMock.post(CATALOG_API_BASE + '/portfolio_items/1/undelete', mockOnce({ body: { id: '1' }}));
     apiClientMock.post(CATALOG_API_BASE + '/portfolio_items/2/undelete', mockOnce({ body: { id: '2' }}));

--- a/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
+++ b/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
@@ -2,36 +2,40 @@
 
 exports[`<PortfolioItem /> should render correctly 1`] = `
 <GalleryItem>
-  <Card
-    className="content-gallery-card"
-    component="article"
-    isHoverable={false}
+  <div
+    className=" "
   >
-    <Link
-      className="card-link"
-      to="/order"
+    <Card
+      className="content-gallery-card"
+      component="article"
+      isHoverable={false}
     >
-      <CardHeader
-        className="card_header"
+      <Link
+        className="card-link"
+        to="/order"
       >
-        <CardIcon
-          height={40}
-          src="/api/catalog/v1.0/portfolio_items/1/icon"
-          style={Object {}}
+        <CardHeader
+          className="card_header"
+        >
+          <CardIcon
+            height={40}
+            src="/api/catalog/v1.0/portfolio_items/1/icon"
+            style={Object {}}
+          />
+        </CardHeader>
+        <ServiceOfferingCardBody
+          description="Bar"
+          display_name="quux"
+          id="1"
+          name="Foo"
+          orderUrl="/order"
         />
-      </CardHeader>
-      <ServiceOfferingCardBody
-        description="Bar"
-        display_name="quux"
-        id="1"
-        name="Foo"
-        orderUrl="/order"
-      />
-      <CardFooter
-        className=""
-        component="div"
-      />
-    </Link>
-  </Card>
+        <CardFooter
+          className=""
+          component="div"
+        />
+      </Link>
+    </Card>
+  </div>
 </GalleryItem>
 `;

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -276,6 +276,7 @@ describe('<Portfolio />', () => {
     apiClientMock.delete(`${CATALOG_API_BASE}/portfolio_items/123`, mockOnce({ body: { restore_key: restoreKey }}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123`, mockOnce({ body: { data: []}}));
+    apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items`, mockOnce({ body: { data: []}}));
 
     /**
      * undo endpoint
@@ -303,7 +304,7 @@ describe('<Portfolio />', () => {
         /**
          * trigger notification undo click
          */
-        const notification = store.getActions()[5].payload.description;
+        const notification = store.getActions()[7].payload.description;
         const notificationWrapper = mount(<IntlProvider locale="en">{ notification }</IntlProvider>);
         notificationWrapper.find('a span').simulate('click');
       });


### PR DESCRIPTION
### Changes
- switched order of async calls when removing portfolio items
  - undo notification is not showed until items are removed, list is updated and rendered
  - portfolio items list update is now part of the remove action instead of being called after remove is finished
- added state mutation on portfolio items remove pending/success
  - this causes the add/remove items buttons to be disabled correctly
- added disabled state to portfolio items while item is being removed
  - adds gray overlay
  - disables events on card (user can no longer redirect to item which is being deleted)

![disable item in progress](https://user-images.githubusercontent.com/22619452/59750921-e14e0780-927f-11e9-96a8-3223d5e274ce.gif)

cc @sbuenafe-rh