### PR TITLE
Disabled pointer events on disabled toolbar links.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -202,6 +202,10 @@
   }
 }
 
+.disabled-link {
+  pointer-events: none
+}
+
 //pf-4 fixes
 /**
 * non working pf display modifier: https://www.patternfly.org/v4/documentation/core/utilities/display#display-block

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolios-filter-toolbar.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolios-filter-toolbar.test.js.snap
@@ -59,6 +59,7 @@ exports[`<PortfoliosFilterToolbar /> should render correctly 1`] = `
           key="portfolio-button-group/single-toolbar-item"
         >
           <Component
+            className=""
             component="Link"
             key="create-portfolio-button/button-link"
             to="/portfolios/add-portfolio"

--- a/src/toolbar/helpers.js
+++ b/src/toolbar/helpers.js
@@ -14,6 +14,7 @@ export const createLinkButton = ({ to, ...item }) => ({
   component: toolbarComponentTypes.LINK,
   to,
   key: `${item.key}/button-link`,
+  className: item.isDisabled ? 'disabled-link' : '',
   fields: [{
     component: toolbarComponentTypes.BUTTON,
     ...item


### PR DESCRIPTION
### Bug fixes
- links on toolbars were clickable even when they were in `disabled` state
  - disabled all pointer events if toolbar link is marked as `disabled`