### PR TITLE
Fix portfolio-item-card link.

### DIFF
--- a/src/smart-components/portfolio/portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item.js
@@ -33,11 +33,9 @@ const PortfolioItem = props => {
           <Card className="content-gallery-card progress-overlay" />
         ) }
         <Card className="content-gallery-card">
-          { props.isSelectable ? renderCardContent() : (
-            <Link to={ props.orderUrl } className="card-link" >
-              { renderCardContent() }
-            </Link>
-          ) }
+          <Link to={ props.orderUrl } className="card-link" >
+            { renderCardContent() }
+          </Link>
         </Card>
       </div>
     </GalleryItem>


### PR DESCRIPTION
### Bug fixes
- portfolio item card was not rendering link on selectable cards
 (caused by: https://github.com/ManageIQ/catalog-ui/pull/222/files#diff-4701f3d3e807955fb77dc7e28ba59048L175)