### PR TITLE
Modified order modal to accept different UI schema types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -900,17 +900,17 @@
       }
     },
     "@data-driven-forms/pf4-component-mapper": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-1.11.0.tgz",
-      "integrity": "sha512-IZzmijukSHbRI7X6Pj+jRjUHTOtzBsMStuWgDhgD0WEVwe+WhmFTuRpgmXdDbdKWoOha4BY2CyvMNTNrk/OiRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-1.12.2.tgz",
+      "integrity": "sha512-28C2U0d5u7FpGc/a9pw/MOImkaIP0AbeHetf10LJHaqSjIs5CVpi0sFFs6FcRwNL8Df+NrCjmr63EsPu4XOtDg==",
       "requires": {
         "@patternfly/patternfly-next": "^1.0.87"
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.11.0.tgz",
-      "integrity": "sha512-d6P0dXes7YCk4wS6uAK4N7cqsmXMFrHHrG07n4sTfUzCAoFa/IWaqtUvsFcxBUMos3bdQ3VXZXYQA0KiKDKh1g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.12.2.tgz",
+      "integrity": "sha512-YrnKxCNVJpH2InYbH2M3BHKtn9kINC7miqG3zXXSr1lZUdM7gUQI3LLiVtWby7Y2ImtMEVmkHN1TDEE79OsAWQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.1.0",
         "final-form": "^4.12.0",
@@ -5851,9 +5851,9 @@
       }
     },
     "final-form": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.15.0.tgz",
-      "integrity": "sha512-A7pvzFAZ/mswLfU4pMKnB+otx3ttv8dO6/X+gWqhUSP+EpNsMenY88PHuGNJ9bIkhYcwF1ErXB8b2E2EMHKBLg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.16.1.tgz",
+      "integrity": "sha512-nUY6ZyFRvnOhSukqpmzm6pt38qYjCA6zSeW630CcfOvy0tBM+Wy0ZLIE36y/QiUfuAtMEJWp8k7GK5LqrqubEw==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@data-driven-forms/pf4-component-mapper": "^1.11.0",
-    "@data-driven-forms/react-form-renderer": "^1.11.0",
+    "@data-driven-forms/pf4-component-mapper": "^1.12.2",
+    "@data-driven-forms/react-form-renderer": "^1.12.2",
     "@manageiq/topological_inventory": "~1.1.0",
     "@patternfly/react-core": "3.16.10",
     "@patternfly/react-icons": "3.7.2",

--- a/src/presentational-components/shared/pf4-select-wrapper.js
+++ b/src/presentational-components/shared/pf4-select-wrapper.js
@@ -73,6 +73,7 @@ const Pf4SelectWrapper = ({
   dataType,
   initialKey,
   id,
+  initialValue,
   ...rest
 }) => {
   const { error, touched } = meta;
@@ -105,7 +106,8 @@ Pf4SelectWrapper.propTypes = {
   hideLabel: PropTypes.bool,
   formOptions: PropTypes.object,
   dataType: PropTypes.string,
-  initialKey: PropTypes.any
+  initialKey: PropTypes.any,
+  initialValue: PropTypes.any
 };
 
 export default Pf4SelectWrapper;


### PR DESCRIPTION
~~Merge only after https://github.com/data-driven-forms/react-forms/pull/26. There was a bug with argument assignment to one of the validator types.~~

### Changes
- no visual changes
- added simple function that creates correct schema for order modal form
  - there is no explicit way to identify schema from Openshift, that should be added
- now we can order items from both openshift and Tower