### PR TITLE
Show description instead of long_description on product card.

### DIFF
--- a/src/presentational-components/shared/service-offering-body.js
+++ b/src/presentational-components/shared/service-offering-body.js
@@ -15,7 +15,7 @@ const ServiceOfferingCardBody = ({ name, display_name, distributor, ...props }) 
       </Text>
       <Text component={ TextVariants.small }>{ distributor }&nbsp;</Text>
     </TextContent>
-    <ItemDetails { ...props } toDisplay={ [ props.long_description ? 'long_description' : 'description' ] } />
+    <ItemDetails { ...props } toDisplay={ [ props.description ? 'description' : 'long_description' ] } />
   </CardBody>
 );
 
@@ -23,7 +23,8 @@ ServiceOfferingCardBody.propTypes = {
   name: PropTypes.string,
   display_name: PropTypes.string,
   distributor: PropTypes.string,
-  long_description: PropTypes.string
+  long_description: PropTypes.string,
+  description: PropTypes.string
 };
 
 export default ServiceOfferingCardBody;


### PR DESCRIPTION
Show description on product cards instead of long description. Long description is used as fallback instead to minimize the change of having empty cards.

![screenshot-ci foo redhat com-1337-2019 07 26-09-15-26](https://user-images.githubusercontent.com/22619452/61933442-28699f80-af86-11e9-9409-7f9fabc64462.png)
