### PR TITLE
Hide empty attributes in product detail page.

### DIFF
--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
@@ -14,14 +14,26 @@ const getWorkflowTitle = (workflows, workflowRef) => {
 const ItemDetailDescription = ({ product, url, workflows, workflow, setWorkflow }) => (
   <Fragment>
     <TextContent>
-      <Text component={ TextVariants.p }>{ product.description }</Text>
-      <Text component={ TextVariants.p }><a href="javascript:void(0)">Sample repository</a></Text>
-      <Text component={ TextVariants.h6 }>Overview</Text>
-      <Text component={ TextVariants.p }>{ product.description }</Text>
-      <Text component={ TextVariants.p }>{ product.long_description }</Text>
-      <Text component={ TextVariants.p }><a href={ product.support_url } target="_blank" rel="noopener noreferrer">Learn more</a></Text>
-      <Text component={ TextVariants.h6 }>Documentation</Text>
-      <Text component={ TextVariants.p }><a href={ product.documentation_url } target="_blank" rel="noopener noreferrer">Doc link</a></Text>
+      { (product.description || product.long_description) && (
+        <Text component={ TextVariants.h6 }>Overview</Text>
+      ) }
+      { product.description && (
+        <Text component={ TextVariants.p }>{ product.description }</Text>
+      ) }
+      { product.long_description && (
+        <Text component={ TextVariants.p }>{ product.long_description }</Text>
+      ) }
+      { product.support_url && (
+        <Text component={ TextVariants.p }><a href={ product.support_url } target="_blank" rel="noopener noreferrer">Learn more</a></Text>
+      ) }
+      { product.documentation_url && (
+        <Fragment>
+          <Text component={ TextVariants.h6 }>Documentation</Text>
+          <Text component={ TextVariants.p }>
+            <a href={ product.documentation_url } target="_blank" rel="noopener noreferrer">Doc link</a>
+          </Text>
+        </Fragment>
+      ) }
       <Route exact path={ `${url}` } render={ () => (
         <Fragment>
           <Text component={ TextVariants.h6 }>Approval workflow</Text>

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-description.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-description.test.js.snap
@@ -34,32 +34,6 @@ exports[`<ItemDetailDescription /> should render correctly 1`] = `
     >
       <Text
         className=""
-        component="p"
-      >
-        <p
-          className=""
-          data-pf-content={true}
-        >
-          Product description
-        </p>
-      </Text>
-      <Text
-        className=""
-        component="p"
-      >
-        <p
-          className=""
-          data-pf-content={true}
-        >
-          <a
-            href="javascript:void(0)"
-          >
-            Sample repository
-          </a>
-        </p>
-      </Text>
-      <Text
-        className=""
         component="h6"
       >
         <h6
@@ -206,32 +180,6 @@ exports[`<ItemDetailDescription /> should render correctly in edit variant 1`] =
     <div
       className="pf-c-content"
     >
-      <Text
-        className=""
-        component="p"
-      >
-        <p
-          className=""
-          data-pf-content={true}
-        >
-          Product description
-        </p>
-      </Text>
-      <Text
-        className=""
-        component="p"
-      >
-        <p
-          className=""
-          data-pf-content={true}
-        >
-          <a
-            href="javascript:void(0)"
-          >
-            Sample repository
-          </a>
-        </p>
-      </Text>
       <Text
         className=""
         component="h6"


### PR DESCRIPTION
- empty attributes are no longer showing on portfolio item detail
- removed sample repository link because it was always a dead link
- removed duplicate description text and move overview section to the top

![screenshot-ci foo redhat com-1337-2019 07 26-09-36-08](https://user-images.githubusercontent.com/22619452/61934522-d0806800-af88-11e9-8b89-b571bb488d5f.png)
