### PR TITLE
Filter sources by application type

### DIFF
--- a/src/helpers/platform/platform-helper.js
+++ b/src/helpers/platform/platform-helper.js
@@ -1,12 +1,27 @@
-import { getAxiosInstance, getSourcesApi, getTopologocalInventoryApi } from '../shared/user-login';
-import { TOPOLOGICAL_INVENTORY_API_BASE } from '../../utilities/constants';
+import { getAxiosInstance, getSourcesApi, getTopologocalInventoryApi, getGraphqlInstance } from '../shared/user-login';
+import { TOPOLOGICAL_INVENTORY_API_BASE, SOURCES_API_BASE } from '../../utilities/constants';
 
 const sourcesApi = getSourcesApi();
 const topologicalApi = getTopologocalInventoryApi();
 const axiosInstance = getAxiosInstance();
+const graphqlInstance = getGraphqlInstance();
+
+const sourcesQuery = `
+query {
+  application_types (filter: { name: "/insights/platform/catalog" }) {
+    id
+    name
+    sources {
+      id
+      name
+    }
+  }
+}`;
 
 export function getPlatforms() {
-  return sourcesApi.listSources();
+  return graphqlInstance.post(`${SOURCES_API_BASE}/graphql`, { query: sourcesQuery })
+  .then(({ data: { application_types }}) => application_types)
+  .then(([{ sources }]) => sources);
 }
 
 export function getPlatform(platformId) {

--- a/src/helpers/platform/platform-helper.js
+++ b/src/helpers/platform/platform-helper.js
@@ -14,6 +14,7 @@ query {
     sources {
       id
       name
+      source_type_id
     }
   }
 }`;

--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -82,3 +82,28 @@ export function getWorkflowApi() {
 export function getAxiosInstance() {
   return axiosInstance;
 }
+
+const grapqlInstance = axios.create();
+grapqlInstance.interceptors.request.use(async config => {
+  await window.insights.chrome.auth.getUser();
+  return config;
+});
+/**
+ * Graphql does not return error response when the qery fails.
+ * Instead it returns 200 response with error object.
+ * We catch it and throw it to trigger notification middleware
+ */
+grapqlInstance.interceptors.response.use(({ data }) => {
+  if (data.errors) {
+    throw {
+      message: data.errors[0].errorType,
+      data: data.errors[0].message
+    };
+  }
+
+  return data;
+});
+
+export function getGraphqlInstance() {
+  return grapqlInstance;
+}

--- a/src/redux/actions/platform-actions.js
+++ b/src/redux/actions/platform-actions.js
@@ -1,10 +1,12 @@
 import * as ActionTypes from '../action-types';
 import * as PlatformHelper from '../../helpers/platform/platform-helper';
 
-const doFetchPlatforms = () => ({
-  type: ActionTypes.FETCH_PLATFORMS,
-  payload: PlatformHelper.getPlatforms().then(({ data }) => data)
-});
+const doFetchPlatforms = () => dispatch => {
+  dispatch({ type: `${ActionTypes.FETCH_PLATFORMS}_PENDING` });
+  return PlatformHelper.getPlatforms()
+  .then(data => dispatch({ type: `${ActionTypes.FETCH_PLATFORMS}_FULFILLED`, payload: data }))
+  .catch(error => dispatch({ type: `${ActionTypes.FETCH_PLATFORMS}_REJECTED`, payload: error }));
+};
 
 export const fetchPlatforms = () => (dispatch) => dispatch(doFetchPlatforms());
 

--- a/src/test/redux/actions/platform-actions.test.js
+++ b/src/test/redux/actions/platform-actions.test.js
@@ -30,11 +30,15 @@ describe('Platform actions', () => {
         isPlatformDataLoading: false
       }
     });
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({
-      body: { data: [{
-        id: '1',
-        name: 'Source 1'
-      }]}
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({
+      body: { data: {
+        application_types: [{
+          sources: [{
+            id: '1',
+            name: 'Source 1'
+          }]
+        }]
+      }}
     }));
 
     const expectedActions = [{
@@ -55,19 +59,21 @@ describe('Platform actions', () => {
         isPlatformDataLoading: false
       }
     });
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({
-      status: 500
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      errors: [{ message: 'error', errorType: 'Some error title' }]
+    }
     }));
 
     const expectedActions = [
       { type: `${FETCH_PLATFORMS}_PENDING` }, {
         type: `${ADD_NOTIFICATION}`,
-        payload: expect.objectContaining({ variant: 'danger' })
+        payload: expect.objectContaining({ variant: 'danger', message: 'Some error title', data: 'error' })
       },
       expect.objectContaining({ type: `${FETCH_PLATFORMS}_REJECTED` })
     ];
 
     return store.dispatch(fetchPlatforms()).catch(() => {
+      console.log(store.getActions());
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/test/smart-components/platform/platforms.test.js
+++ b/src/test/smart-components/platform/platforms.test.js
@@ -34,7 +34,13 @@ describe('<Platforms />', () => {
 
   it('should mount and fetch platforms data', (done) => {
     const store = mockStore(initialState);
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: [{ id: '1', name: 'foo' }]}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{
+          sources: [{ id: '1', name: 'foo' }]
+        }]
+      }}
+    }));
     mount(<MemoryRouter><Platforms { ...initialProps } store={ store } /></MemoryRouter>);
     setImmediate(() => {
       const expectedActions = [{
@@ -71,7 +77,9 @@ describe('<Platforms />', () => {
       }
     };
     const Provider = mockBreacrumbsStore(initialState, middlewares);
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: [{ id: '1', name: 'foo' }]}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: { application_types: [{ sources: [{ id: '1', name: 'foo' }]}]}
+    }}));
     const wrapper = mount(
       <Provider>
         <MemoryRouter initialEntries={ [ '/platforms' ] }><Platforms { ...initialProps } /></MemoryRouter>

--- a/src/test/smart-components/portfolio/add-products-to-portfolio/add-products-to-portfolio.test.js
+++ b/src/test/smart-components/portfolio/add-products-to-portfolio/add-products-to-portfolio.test.js
@@ -54,7 +54,13 @@ describe('<AddProductsToPortfolio />', () => {
         }
       }
     });
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: [{ id: '1', name: 'foo' }]}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources:
+          [{ id: '1', name: 'foo' }]
+        }]
+      }
+    }}));
 
     const wrapper = mount(
       <ComponentWrapper store={ store }>
@@ -101,7 +107,13 @@ describe('<AddProductsToPortfolio />', () => {
         }
       }
     });
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: [{ id: '1', name: 'foo' }]}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources:
+          [{ id: '1', name: 'foo' }]
+        }]
+      }
+    }}));
     apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings?filter%5Barchived_at%5D%5Bnil%5D=&limit=50&offset=0`, mockOnce({
       body: {
         data: [], meta: {}}

--- a/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
@@ -83,7 +83,13 @@ describe('<PortfolioItemDetail />', () => {
       }
     }));
     apiClientMock.get(new RegExp(`${CATALOG_API_BASE}/portfolio_items/*`), mockOnce({ body: { name: 'foo', id: 'bar' }}));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources:
+          []
+        }]
+      }
+    }}));
     const wrapper = mount(
       <ComponentWrapper store={ store }>
         <PortfolioItemDetail { ...initialProps } />
@@ -117,7 +123,13 @@ describe('<PortfolioItemDetail />', () => {
       }
     }));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolio_items/123`, mockOnce({ body: { name: 'foo', id: 'bar' }}));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources:
+          []
+        }]
+      }
+    }}));
 
     const wrapper = mount(
       <ComponentWrapper store={ store } initialEntries={ [ '/foo/123' ] }>
@@ -155,7 +167,13 @@ describe('<PortfolioItemDetail />', () => {
     apiClientMock.get(`${CATALOG_API_BASE}/portfolio_items/123/provider_control_parameters`, mockOnce({
       body: { properties: { namespace: { enum: []}}}
     }));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources:
+          []
+        }]
+      }
+    }}));
 
     const wrapper = mount(
       <ComponentWrapper store={ store } initialEntries={ [ '/foo/123', '/foo/123/order' ] } initialIndex={ 0 }>

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -80,7 +80,13 @@ describe('<Portfolio />', () => {
       type: `${FETCH_PLATFORMS}_FULFILLED`
     }) ];
 
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{
+          sources: []
+        }]
+      }
+    }}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123`, mockOnce({ body: {}}));
 
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items?limit=50&offset=0`, mockOnce({ body: { data: []}}));
@@ -101,7 +107,13 @@ describe('<Portfolio />', () => {
     const store = mockStore({ ...initialState, platformReducer: { platforms: [], platformItems: {}}});
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items?limit=50&offset=0`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123`, mockOnce({ body: { data: []}}));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{
+          sources: []
+        }]
+      }
+    }}));
 
     const wrapper = mount(
       <ComponentWrapper store={ store } initialEntries={ [ '/portfolios/detail/123/add-products' ] }>
@@ -140,7 +152,13 @@ describe('<Portfolio />', () => {
       expect(req).toBeTruthy();
       return res.status(200);
     }));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources:
+          []
+        }]
+      }
+    }}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items?limit=50&offset=0`, mockOnce({ body: { data: []}}));
 
     const wrapper = mount(
@@ -175,7 +193,12 @@ describe('<Portfolio />', () => {
     });
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items?limit=50&offset=0`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123`, mockOnce({ body: { data: []}}));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources: []
+        }]
+      }
+    }}));
 
     const wrapper = mount(
       <ComponentWrapper store={ store } initialEntries={ [ '/portfolios/detail/123/remove-portfolio' ] }>
@@ -208,7 +231,11 @@ describe('<Portfolio />', () => {
     });
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items?limit=50&offset=0`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123`, mockOnce({ body: { data: []}}));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{ sources: []}]
+      }
+    }}));
 
     const wrapper = mount(
       <ComponentWrapper store={ store } initialEntries={ [ '/portfolios/detail/123/order/321' ] }>
@@ -238,7 +265,9 @@ describe('<Portfolio />', () => {
     });
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123/portfolio_items?limit=50&offset=0`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/123`, mockOnce({ body: { data: []}}));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: { application_types: [{ sources: []}]}
+    }}));
 
     const wrapper = mount(
       <ComponentWrapper store={ store } initialEntries={ [ '/portfolios/detail/123' ] }>
@@ -279,7 +308,13 @@ describe('<Portfolio />', () => {
 
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/321/portfolio_items?limit=50&offset=0`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios/321`, mockOnce({ body: { data: []}}));
-    apiClientMock.get(`${SOURCES_API_BASE}/sources`, mockOnce({ body: { data: []}}));
+    apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {
+      data: {
+        application_types: [{
+          sources: []
+        }]
+      }
+    }}));
 
     /**
      * remove portfolio items calls

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -15,7 +15,7 @@ import loadingStateMiddleware from './loading-state-middleware';
 
 const registry = new ReducerRegistry({}, [ thunk, promiseMiddleware(), notificationsMiddleware({
   errorTitleKey: [ 'errors', 'message', 'statusText' ],
-  errorDescriptionKey: [ 'data.errors', 'data.error', 'data.message', 'response.body.errors', 'data', 'stack' ]
+  errorDescriptionKey: [ 'data.errors', 'data.error', 'data.message', 'response.body.errors', 'data', 'errorMessage', 'stack' ]
 }), loadingStateMiddleware, reduxLogger ]);
 registry.register({
   orderReducer: applyReducerHash(orderReducer, orderInitialState),


### PR DESCRIPTION
### Changes
- we only query sources that are of `/insights/platform/catalog` application type
- added graphql API instance
  - added interceptor to catch graphql error response and throw it as an actual error

Now we can see only the Tower source (in both platforms and when adding items to portfolios):
![screenshot-ci foo redhat com-1337-2019 08 22-15-03-27](https://user-images.githubusercontent.com/22619452/63516799-0106e380-c4ee-11e9-91cb-530f2b84155c.png)
