### PR TITLE
Removed platformId undefined override in card icon component.

### DIFF
--- a/src/presentational-components/shared/card-icon.js
+++ b/src/presentational-components/shared/card-icon.js
@@ -19,6 +19,7 @@ const defaultPlatformIcon = (platformId, platformList) => {
   if (!platformId) {
     return CardIconDefault;
   }
+
   if (!platformList || platformList.empty || !platformId) {
     return CardIconDefault;
   }
@@ -29,7 +30,7 @@ const defaultPlatformIcon = (platformId, platformList) => {
   }
 };
 
-const CardIcon = ({ src, height, platformId = undefined }) => {
+const CardIcon = ({ src, height, platformId  }) => {
   const [ isLoaded, setLoaded ] = useState(false);
   const [ isUnknown, setUnknown ] = useState(false);
   const  platformList = useSelector(state => (state.platformReducer ? state.platformReducer.platforms : {}));


### PR DESCRIPTION
`platformId` prop was always set to `undefined`. That caused the fallback Icon not to be set. 

The `undefined` should be in default props but component props have this vale by default it they are not set.

![screenshot-ci foo redhat com-1337-2019 08 22-15-40-08](https://user-images.githubusercontent.com/22619452/63519372-21856c80-c4f3-11e9-8bc3-3269c41e4633.png)
