### PR TITLE
Hide vendor data when its empty in portfolio item detail.

### DIFF
--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
@@ -6,7 +6,9 @@ const ItemDetailInfoBar = ({ product, source, portfolio }) => (
   <TextContent>
     <Text component={ TextVariants.h6 }>Platform <br />{ source.name }</Text>
     <Text component={ TextVariants.h6 }>Portfolio <br />{ portfolio.display_name || portfolio.name }</Text>
-    <Text component={ TextVariants.h6 }>Vendor <br />{ product.distributor || 'Missing API data' }</Text>
+    { product.distributor && (
+      <Text component={ TextVariants.h6 }>Vendor <br />{ product.distributor }</Text>
+    ) }
     <Text component={ TextVariants.h6 }>Created at <br />{ new Date(product.updated_at || product.created_at).toLocaleDateString() }</Text>
   </TextContent>
 );

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
@@ -78,7 +78,7 @@ exports[`<ItemDetailInfoBar /> should render correctly 1`] = `
 </ItemDetailInfoBar>
 `;
 
-exports[`<ItemDetailInfoBar /> should render correctly with fallback values 1`] = `
+exports[`<ItemDetailInfoBar /> should render correctly with fallback values withouth vendor 1`] = `
 <ItemDetailInfoBar
   portfolio={
     Object {
@@ -131,9 +131,76 @@ exports[`<ItemDetailInfoBar /> should render correctly with fallback values 1`] 
           className=""
           data-pf-content={true}
         >
+          Created at 
+          <br />
+          3/22/2019
+        </h6>
+      </Text>
+    </div>
+  </TextContent>
+</ItemDetailInfoBar>
+`;
+
+exports[`<ItemDetailInfoBar /> should render correctly with vendor 1`] = `
+<ItemDetailInfoBar
+  distributor="Foo distributor"
+  portfolio={
+    Object {
+      "display_name": "baz",
+      "name": "quux",
+    }
+  }
+  product={
+    Object {
+      "created_at": "Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)",
+      "distributor": "foo",
+      "updated_at": "Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)",
+    }
+  }
+  source={
+    Object {
+      "name": "bar",
+    }
+  }
+>
+  <TextContent>
+    <div
+      className="pf-c-content"
+    >
+      <Text
+        component="h6"
+      >
+        <h6
+          className=""
+          data-pf-content={true}
+        >
+          Platform 
+          <br />
+          bar
+        </h6>
+      </Text>
+      <Text
+        component="h6"
+      >
+        <h6
+          className=""
+          data-pf-content={true}
+        >
+          Portfolio 
+          <br />
+          baz
+        </h6>
+      </Text>
+      <Text
+        component="h6"
+      >
+        <h6
+          className=""
+          data-pf-content={true}
+        >
           Vendor 
           <br />
-          Missing API data
+          foo
         </h6>
       </Text>
       <Text

--- a/src/test/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.test.js
@@ -28,7 +28,7 @@ describe('<ItemDetailInfoBar />', () => {
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('should render correctly with fallback values', () => {
+  it('should render correctly with fallback values withouth vendor', () => {
     initialProps = {
       product: {
         created_at: 'Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)'
@@ -41,6 +41,11 @@ describe('<ItemDetailInfoBar />', () => {
       }
     };
     const wrapper = mount(<ItemDetailInfoBar { ...initialProps } />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render correctly with vendor', () => {
+    const wrapper = mount(<ItemDetailInfoBar { ...initialProps } distributor="Foo distributor" />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
### Changes
- empty vendor name is now hidden

Before:
![Screenshot from 2019-09-18 08-33-27](https://user-images.githubusercontent.com/12769982/65149137-91521e80-d9ef-11e9-869c-fd146101ffac.png)

After:

![Screenshot from 2019-09-18 08-32-21](https://user-images.githubusercontent.com/12769982/65149167-9dd67700-d9ef-11e9-869a-2e348f16cd61.png)