### PR TITLE
Fixed add/edit portfolio modal

### DIFF
--- a/src/constants/nullable-attributes.js
+++ b/src/constants/nullable-attributes.js
@@ -1,3 +1,8 @@
 export const PORTFOLIO_ITEM_NULLABLE = [
   'display_name', 'description', 'long_description', 'distributor', 'documentation_url', 'support_url', 'workflow_ref'
 ];
+
+export const PORTFOLIO_NULLABLE = [
+  'description',
+  'workflow_ref'
+];

--- a/src/forms/portfolio-form.schema.js
+++ b/src/forms/portfolio-form.schema.js
@@ -37,6 +37,7 @@ export const createPortfolioSchema = (newRecord, loadWorkflows, portfolioId) => 
     name: 'workflow_ref',
     component: componentTypes.SELECT,
     loadOptions: asyncFormValidator(loadWorkflows),
-    isSearchable: true
+    isSearchable: true,
+    isClearable: true
   }]
 });

--- a/src/forms/portfolio-form.schema.js
+++ b/src/forms/portfolio-form.schema.js
@@ -12,7 +12,7 @@ const validateName = (name, portfolioId) => fetchPortfolioByName(name)
   return data.find(portfolio => portfolio.name === name && portfolio.id !== portfolioId)
     ? 'Name has already been taken'
     : undefined;
-});
+}).catch(error => error.data);
 
 const debouncedValidator = asyncFormValidator(validateName);
 

--- a/src/helpers/portfolio/portfolio-helper.js
+++ b/src/helpers/portfolio/portfolio-helper.js
@@ -1,6 +1,6 @@
 import { getAxiosInstance, getPortfolioApi, getPortfolioItemApi } from '../shared/user-login';
 import { CATALOG_API_BASE } from '../../utilities/constants';
-import { PORTFOLIO_ITEM_NULLABLE } from '../../constants/nullable-attributes';
+import { PORTFOLIO_ITEM_NULLABLE, PORTFOLIO_NULLABLE } from '../../constants/nullable-attributes';
 import { udefinedToNull } from '../shared/helpers';
 
 const axiosInstance = getAxiosInstance();
@@ -56,7 +56,7 @@ export async function addToPortfolio(portfolioId, items) {
 }
 
 export async function updatePortfolio(portfolioData) {
-  return await portfolioApi.updatePortfolio(portfolioData.id, portfolioData);
+  return await portfolioApi.updatePortfolio(portfolioData.id,  udefinedToNull(portfolioData, PORTFOLIO_NULLABLE));
 }
 
 export async function removePortfolio(portfolioId) {

--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -9,6 +9,11 @@ import { AccessApi, PrincipalApi, GroupApi } from '@redhat-cloud-services/rbac-c
 
 const axiosInstance = axios.create();
 
+const paramSerializer = config => {
+  config.url = config.url.replace(/(?==)*%+/g, value => value.replace(/%/g, '%25%0A'));
+  return config;
+};
+
 const resolveInterceptor = response => response.data || response;
 const errorInterceptor = (error = {}) => {
   throw { ...error.response };
@@ -19,6 +24,7 @@ axiosInstance.interceptors.request.use(async config => {
   await window.insights.chrome.auth.getUser();
   return config;
 });
+axiosInstance.interceptors.request.use(paramSerializer);
 axiosInstance.interceptors.response.use(resolveInterceptor);
 axiosInstance.interceptors.response.use(null, errorInterceptor);
 

--- a/src/test/forms/__snapshots__/portfolio-form.schema.test.js.snap
+++ b/src/test/forms/__snapshots__/portfolio-form.schema.test.js.snap
@@ -19,6 +19,7 @@ Object {
     },
     Object {
       "component": "select-field",
+      "isClearable": true,
       "isSearchable": true,
       "label": "Approval workflow",
       "loadOptions": [Function],
@@ -47,6 +48,7 @@ Object {
     },
     Object {
       "component": "select-field",
+      "isClearable": true,
       "isSearchable": true,
       "label": "Approval workflow",
       "loadOptions": [Function],

--- a/src/test/smart-components/portfolio/add-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/add-portfolio-modal.test.js
@@ -88,7 +88,8 @@ describe('<AddPortfolioModal />', () => {
         label: 'Approval workflow',
         name: 'workflow_ref',
         loadOptions: expect.any(Function),
-        isSearchable: true
+        isSearchable: true,
+        isClearable: true
       }]
     };
 

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -77,11 +77,11 @@ describe('<Portfolio />', () => {
     }, {
       type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`
     }, expect.objectContaining({
+      type: `${FETCH_PLATFORMS}_FULFILLED`
+    }), expect.objectContaining({
       type: `${FETCH_PORTFOLIO}_FULFILLED`
     }), expect.objectContaining({
       type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`
-    }), expect.objectContaining({
-      type: `${FETCH_PLATFORMS}_FULFILLED`
     }) ];
 
     apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: {


### PR DESCRIPTION
### Changes
- added clear able option to to workflow select
  - now that the options are loaded asynchronously, server does not return an empty options obviously
  - clear able select has addition button which deletes the value
- Fixed empty description was not saved
  - when value is deleted from formState its value is `undefined` but API expects `null`
- Fixed URL freeze when trying to save portfolio which has `%` in name
  - this was caused by async validation because the API client is not serializing special characters
  - query was `?filter[name]=%%%` instead of `?filter[name]=%25%0A%25%0A%25%0A.`
  - I will create interceptor function in the JS clients library to cover the rest of platform apps