### PR TITLE
Overwrite only catalog apps in spandx.config

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -5,6 +5,10 @@
 const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
 
 exports.routes = {
-  '/hybrid/catalog': { host: `http://${localhost}:8002` },
-  '/apps/catalog': { host: `http://${localhost}:8002` }
+  '/hybrid/catalog/portfolios': { host: `http://${localhost}:8002` },
+  '/hybrid/catalog/platforms': { host: `http://${localhost}:8002` },
+  '/hybrid/catalog/orders': { host: `http://${localhost}:8002` },
+  '/apps/catalog/portfolios': { host: `http://${localhost}:8002` },
+  '/apps/catalog/platforms': { host: `http://${localhost}:8002` },
+  '/apps/catalog/orders': { host: `http://${localhost}:8002` },
 };


### PR DESCRIPTION
**Description**

Because the catalog menu section contains the approval app, which is not a part of the catalog application, spandx needs to be updated to overwrite only catalog apps.

@karelhala 