### PR TITLE
Fixed order navigation highlight.

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -47,6 +47,7 @@ Element.prototype.scrollTo = () => {};
 // mock insights instance
 global.insights = {
   chrome: {
+    appNavClick: () => {},
     auth: {
       getUser: () => new Promise(resolve => resolve(true))
     }

--- a/src/presentational-components/order/order-notification.js
+++ b/src/presentational-components/order/order-notification.js
@@ -6,7 +6,10 @@ import { clearNotifications } from '@redhat-cloud-services/frontend-components-n
 
 const OrderNotification = ({ id, dispatch }) => (
   <p>
-    You can track the progress of Order # { id } in your <Link onClick={ () => dispatch(clearNotifications()) } to="/orders">Orders</Link> page.
+    You can track the progress of Order # { id } in your <Link onClick={ () => {
+      dispatch(clearNotifications());
+      insights.chrome.appNavClick({ id: 'orders', secondaryNav: true }); // chrome API to trigger navigation
+    } } to="/orders">Orders</Link> page.
   </p>
 );
 


### PR DESCRIPTION
### Changes
- use chrome API to trigger navigation highlight when navigating to orders via notification link.

![order-highlight](https://user-images.githubusercontent.com/22619452/66397815-e674c500-e9dc-11e9-8702-0496e429d7df.gif)
