### PR TITLE
Removed usage of display_name from catalog objects.

### DIFF
--- a/src/constants/nullable-attributes.js
+++ b/src/constants/nullable-attributes.js
@@ -1,5 +1,5 @@
 export const PORTFOLIO_ITEM_NULLABLE = [
-  'display_name', 'description', 'long_description', 'distributor', 'documentation_url', 'support_url', 'workflow_ref'
+  'name', 'description', 'long_description', 'distributor', 'documentation_url', 'support_url', 'workflow_ref'
 ];
 
 export const PORTFOLIO_NULLABLE = [

--- a/src/forms/edit-portfolio-item-form.schema.js
+++ b/src/forms/edit-portfolio-item-form.schema.js
@@ -4,8 +4,8 @@ import asyncFormValidator from '../utilities/async-form-validator';
 const editPortfolioItemSchema = (loadWorkflows) => ({
   fields: [{
     component: componentTypes.TEXT_FIELD,
-    name: 'display_name',
-    label: 'Display name',
+    name: 'name',
+    label: 'Name',
     isRequired: true,
     validate: [{ type: validatorTypes.REQUIRED }]
   }, {

--- a/src/helpers/shared/orders.js
+++ b/src/helpers/shared/orders.js
@@ -4,7 +4,7 @@ export const getOrderIcon = ({ orderItems }) => orderItems[0] && `${CATALOG_API_
 
 export const getOrderPortfolioName = ({ orderItems, id }, portfolioItems) => {
   const portfolioItem = orderItems[0] && portfolioItems.find(({ id }) => orderItems[0].portfolio_item_id === id);
-  return portfolioItem ? portfolioItem.display_name || portfolioItem.name : `Order ${id}`;
+  return portfolioItem ? portfolioItem.name : `Order ${id}`;
 };
 
 export const getOrderPlatformId = ({ orderItems }, portfolioItems) => {

--- a/src/presentational-components/shared/breadcrubms.js
+++ b/src/presentational-components/shared/breadcrubms.js
@@ -29,7 +29,7 @@ const fragmentMapper = {
     title: 'Orders'
   },
   product: {
-    reducer: 'portfolioReducer.portfolioItem.display_name'
+    reducer: 'portfolioReducer.portfolioItem.name'
   }
 };
 

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -216,7 +216,7 @@ export const copyPortfolioItem = (portfolioItemId, copyObject, newPortfolio) => 
     dispatch({ type: ADD_NOTIFICATION, payload: {
       variant: 'success',
       title: 'You have successfully copied a product',
-      description: `${data.display_name} has been copied into ${newPortfolio.name}`,
+      description: `${data.name} has been copied into ${newPortfolio.name}`,
       dismissable: true
     }});
     return data;
@@ -238,7 +238,7 @@ export const updatePortfolioItem = values => dispatch => {
   .then(item => dispatch({
     type: ADD_NOTIFICATION, payload: {
       variant: 'success',
-      title: `Portfolio item "${item.display_name}" was successfully updated`,
+      title: `Portfolio item "${item.name}" was successfully updated`,
       dismissable: true
     }
   }))

--- a/src/smart-components/common/order-modal.js
+++ b/src/smart-components/common/order-modal.js
@@ -24,7 +24,7 @@ const OrderModal = ({ serviceData, closeUrl, history: { push }}) => serviceData 
       <Level>
         <LevelItem className="elipsis-text-overflow">
           <Title headingLevel="h2" size="3xl">
-            { serviceData.display_name }
+            { serviceData.name }
           </Title>
         </LevelItem>
       </Level>

--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -27,7 +27,7 @@ const copySchema = (portfolios, portfolioName, portfolioChange, nameFetching) =>
     name: 'portfolio_id',
     label: 'Portfolio',
     isRequired: true,
-    options: portfolios.map(({ id, display_name, name }) => ({ label: display_name || name, value: id })),
+    options: portfolios.map(({ id, name }) => ({ label: name, value: id })),
     onChange: portfolioChange,
     isDisabled: nameFetching
   }]

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
@@ -22,7 +22,7 @@ const ItemDetailInfoBar = ({ product, source, portfolio }) => (
       <br />
       <div className="elipsis-text-overflow">
         <span>
-          { portfolio.display_name || portfolio.name }
+          { portfolio.name }
         </span>
       </div>
     </Text>
@@ -63,7 +63,6 @@ ItemDetailInfoBar.propTypes = {
     name: PropTypes.string.isRequired
   }).isRequired,
   portfolio: PropTypes.shape({
-    display_name: PropTypes.string,
     name: PropTypes.string.isRequired
   }).isRequired
 };

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -29,7 +29,7 @@ const PortfolioItemDetailToolbar = ({
         <LevelItem>
           <TextContent>
             <Text component={ TextVariants.h1 }>
-              { product.display_name || product.name }
+              { product.name }
             </Text>
           </TextContent>
         </LevelItem>
@@ -65,7 +65,6 @@ PortfolioItemDetailToolbar.propTypes = {
   url: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   product: PropTypes.shape({
-    display_name: PropTypes.string,
     distributor: PropTypes.string,
     name: PropTypes.string.isRequired,
     workflow_ref: PropTypes.string

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
@@ -60,7 +60,7 @@ exports[`<ItemDetailInfoBar /> should render correctly 1`] = `
             className="elipsis-text-overflow"
           >
             <span>
-              baz
+              quux
             </span>
           </div>
         </h6>
@@ -258,7 +258,7 @@ exports[`<ItemDetailInfoBar /> should render correctly with vendor 1`] = `
             className="elipsis-text-overflow"
           >
             <span>
-              baz
+              quux
             </span>
           </div>
         </h6>

--- a/src/test/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.test.js
@@ -30,7 +30,7 @@ describe('<EditPortfolioItem />', () => {
       workflows: [],
       cancelUrl: '/cancel',
       product: {
-        display_name: 'foo',
+        name: 'foo',
         id: '123',
         workflow_ref: '123'
       }
@@ -58,7 +58,7 @@ describe('<EditPortfolioItem />', () => {
     apiClientMock.get(`${APPROVAL_API_BASE}/workflows`, mockOnce({ body: { data: []}}));
     apiClientMock.patch(`${CATALOG_API_BASE}/portfolio_items/123`, mockOnce((req, res) => {
       expect(JSON.parse(req.body())).toEqual({
-        display_name: 'foo',
+        name: 'foo',
         id: '123',
         workflow_ref: '123',
         documentation_url: 'https://www.google.com/',
@@ -74,7 +74,7 @@ describe('<EditPortfolioItem />', () => {
       type: UPDATE_TEMPORARY_PORTFOLIO_ITEM,
       payload: {
 
-        display_name: 'foo',
+        name: 'foo',
         id: '123',
         workflow_ref: '123',
         documentation_url: 'https://www.google.com/',
@@ -87,7 +87,7 @@ describe('<EditPortfolioItem />', () => {
       type: UPDATE_PORTFOLIO_ITEM,
       payload: {
 
-        display_name: 'foo',
+        name: 'foo',
         id: '123',
         workflow_ref: '123',
         documentation_url: 'https://www.google.com/',


### PR DESCRIPTION
UI side of: https://github.com/ManageIQ/catalog-api/pull/428
Depends on: https://github.com/ManageIQ/catalog-api/pull/429

~~Currently i am having an issue with API so I was not able to test it in UI. I want to wait until ill be able to do that.~~

~~(I did contacted Drew about the API issue: `error: "invalid value for "operation", must be one of #{validator.allowable_values}."`)~~

### Changes
- removed usage of `display_name` from catalog entities.