### PR TITLE
Add a description and make the notification for the copy portfolio dismissable

### DIFF
--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -204,7 +204,10 @@ export const copyPortfolio = id => dispatch => {
   return PortfolioHelper.copyPortfolio(id)
   .then(portfolio => {
     dispatch({ type: 'COPY_PORTFOLIO_FULFILLED' });
-    dispatch({ type: ADD_NOTIFICATION, payload: { variant: 'success', title: 'You have successfully copied a portfolio' }});
+    dispatch({ type: ADD_NOTIFICATION, payload: { variant: 'success',
+      title: 'You have successfully copied a portfolio',
+      description: `${portfolio.name} has been copied.}`,
+      dismissable: true }});
     return portfolio;
   })
   .catch(err => dispatch({ type: 'COPY_PORTFOLIO_REJECTED', payload: err }));


### PR DESCRIPTION
 Fixes https://projects.engineering.redhat.com/browse/SSP-725

The existing UX mocks do not have a description nor are dismissable - but the notifications should have a consistent look.

@sbuenafe