### PR TITLE
Rmoved required validations from portfolio item form.

### DIFF
--- a/src/forms/edit-portfolio-item-form.schema.js
+++ b/src/forms/edit-portfolio-item-form.schema.js
@@ -17,34 +17,23 @@ const editPortfolioItemSchema = (loadWorkflows) => ({
   }, {
     component: componentTypes.TEXT_FIELD,
     name: 'long_description',
-    label: 'Long description',
-    isRequired: true,
-    validate: [{ type: validatorTypes.REQUIRED }]
+    label: 'Long description'
   }, {
     component: componentTypes.TEXT_FIELD,
     name: 'distributor',
-    label: 'Vendor',
-    isRequired: true,
-    validate: [{ type: validatorTypes.REQUIRED }]
+    label: 'Vendor'
   }, {
     component: componentTypes.TEXT_FIELD,
     name: 'documentation_url',
     label: 'Documentation URL',
-
-    isRequired: true,
     validate: [{
-      type: validatorTypes.REQUIRED
-    }, {
       type: validatorTypes.URL
     }]
   }, {
     component: componentTypes.TEXT_FIELD,
     name: 'support_url',
     label: 'Support URL',
-    isRequired: true,
     validate: [{
-      type: validatorTypes.REQUIRED
-    }, {
       type: validatorTypes.URL
     }]
   }, {


### PR DESCRIPTION
UI follow up of: https://github.com/ManageIQ/catalog-api/pull/438

cc @syncrou while testing locally i am still seeing the validation error like:
`#/components/schemas/PortfolioItem/properties/distributor don't allow null`

