### PR TITLE
Removed isRequired from product description

### DIFF
--- a/src/forms/edit-portfolio-item-form.schema.js
+++ b/src/forms/edit-portfolio-item-form.schema.js
@@ -11,9 +11,7 @@ const editPortfolioItemSchema = (loadWorkflows) => ({
   }, {
     component: componentTypes.TEXT_FIELD,
     name: 'description',
-    label: 'Description',
-    isRequired: true,
-    validate: [{ type: validatorTypes.REQUIRED }]
+    label: 'Description'
   }, {
     component: componentTypes.TEXT_FIELD,
     name: 'long_description',


### PR DESCRIPTION
Product description is not required via the `PortfolioItem` model https://github.com/ManageIQ/catalog-api/blob/master/app/models/portfolio_item.rb#L11 so removing the `isRequired` in the schema.

This depends on https://github.com/ManageIQ/catalog-api/pull/441

There is still more work to be done for the edits to fully work.
For any `patch` operation all `readOnly` params need to be stripped from the payload:
```
found unpermitted parameters: :id, :service_offering_source_ref, :service_offering_type, :portfolio_id
```

Product edits will work once https://github.com/ManageIQ/catalog-api/pull/441 is merged and the `readOnly` attributes are removed from the `patch` payload.