### PR TITLE
Update catalog portfolio permissions sharing verbs

### DIFF
--- a/src/smart-components/portfolio/share-portfolio-modal.js
+++ b/src/smart-components/portfolio/share-portfolio-modal.js
@@ -10,7 +10,7 @@ import { fetchPortfolios } from '../../redux/actions/portfolio-actions';
 import { fetchShareInfo, sharePortfolio, unsharePortfolio } from '../../redux/actions/share-actions';
 import { fetchRbacGroups } from '../../redux/actions/rbac-actions';
 import { ShareLoader } from '../../presentational-components/shared/loader-placeholders';
-import { permissionOptions } from '../../utilities/constants';
+import { permissionOptions, permissionValues } from '../../utilities/constants';
 
 const SharePortfolioModal = ({
   history: { push },
@@ -34,14 +34,15 @@ const SharePortfolioModal = ({
 
   const initialShares = () => {
     let initialGroupShareList = shareInfo.map((group) => {
+      const groupPermissions = group.permissions.filter((permission) => permissionValues.indexOf(permission) > -1);
       const groupName = group.group_name;
-      let options = permissionOptions.find(perm => (perm.value === group.permissions.sort().join(',')));
+      let options = permissionOptions.find(perm => (perm.value === groupPermissions.sort().join(',')));
       return {
         [groupName]: options ? options.value : 'Unknown'
       };
     });
     let initialShareList = initialGroupShareList.reduce((acc, curr) => ({ ...acc, ...curr }), {});
-
+    console.log('Initial shares: ', initialShareList);
     return initialShareList;
   };
 

--- a/src/smart-components/portfolio/share-portfolio-modal.js
+++ b/src/smart-components/portfolio/share-portfolio-modal.js
@@ -42,7 +42,6 @@ const SharePortfolioModal = ({
       };
     });
     let initialShareList = initialGroupShareList.reduce((acc, curr) => ({ ...acc, ...curr }), {});
-    console.log('Initial shares: ', initialShareList);
     return initialShareList;
   };
 

--- a/src/smart-components/portfolio/share-portfolio-modal.js
+++ b/src/smart-components/portfolio/share-portfolio-modal.js
@@ -61,7 +61,7 @@ const SharePortfolioModal = ({
           if (share.permissions.length > data[share.group_name].split(',').length) {
             sharePromises.push(unsharePortfolio({
               id: portfolioId,
-              permissions: [ 'catalog:portfolios:write' ],
+              permissions: [ 'catalog:portfolios:update' ],
               group_uuid: share.group_uuid
             }));
           }

--- a/src/smart-components/portfolio/share-portfolio-modal.js
+++ b/src/smart-components/portfolio/share-portfolio-modal.js
@@ -56,7 +56,8 @@ const SharePortfolioModal = ({
       let initialPerm = share.permissions.sort().join(',');
       if (data[share.group_name] !== initialPerm) {
         if (!data[share.group_name]) {
-          sharePromises.push(unsharePortfolio({ id: portfolioId, permissions: share.permissions, group_uuid: share.group_uuid }));
+          const sharePermissions = share.permissions.filter((permission) => permissionValues.indexOf(permission) > -1);
+          sharePromises.push(unsharePortfolio({ id: portfolioId, permissions: sharePermissions, group_uuid: share.group_uuid }));
         }
         else {
           if (share.permissions.length > data[share.group_name].split(',').length) {

--- a/src/test/smart-components/portfolio/share-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/share-portfolio-modal.test.js
@@ -105,7 +105,7 @@ describe('<SharePortfolioModal', () => {
     }));
     apiClientMock.post(`${CATALOG_API_BASE}/portfolios/123/unshare`, mockOnce((req, res) => {
       expect(JSON.parse(req.body())).toEqual({
-        permissions: [ 'catalog:portfolios:write' ],
+        permissions: [ 'catalog:portfolios:update' ],
         group_uuids: [ null ]
       });
       return res.status(200);

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -5,7 +5,7 @@ export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topologi
 export const RBAC_API_BASE = `${process.env.BASE_PATH}/rbac/v1`;
 
 export const permissionOptions = [{
-  value: 'catalog:portfolios:order,catalog:portfolios:read,catalog:portfolios:write',
+  value: 'catalog:portfolios:order,catalog:portfolios:read,catalog:portfolios:update',
   label: 'Can order/edit'
 }, {
   value: 'catalog:portfolios:order,catalog:portfolios:read', label: 'Can order/view'

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -4,6 +4,8 @@ export const APPROVAL_API_BASE = `${process.env.BASE_PATH}/approval/v1.0`;
 export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topological-inventory/v1.0`;
 export const RBAC_API_BASE = `${process.env.BASE_PATH}/rbac/v1`;
 
+export const permissionValues = [ 'catalog:portfolios:order', 'catalog:portfolios:read', 'catalog:portfolios:update' ];
+
 export const permissionOptions = [{
   value: 'catalog:portfolios:order,catalog:portfolios:read,catalog:portfolios:update',
   label: 'Can order/edit'


### PR DESCRIPTION
Update the catalog portfolio permissions sharing verbs. 
limit the permission verbs to be updated via the UI to the ones in permissionValues array.

