### PR TITLE
Fixed unpermitted parameters in edit portfolio item payload.

### DIFF
--- a/src/helpers/portfolio/portfolio-helper.js
+++ b/src/helpers/portfolio/portfolio-helper.js
@@ -88,8 +88,8 @@ export function fetchProviderControlParameters(portfolioItemId) {
     }}));
 }
 
-export async function updatePortfolioItem(portfolioItem) {
-  return await portfolioItemApi.updatePortfolioItem(portfolioItem.id, udefinedToNull(portfolioItem, PORTFOLIO_ITEM_NULLABLE));
+export async function updatePortfolioItem({ id, service_offering_source_ref, portfolio_id, ...portfolioItem }) {
+  return await portfolioItemApi.updatePortfolioItem(id, udefinedToNull(portfolioItem, PORTFOLIO_ITEM_NULLABLE));
 }
 
 export function fetchPortfolioByName(name = '') {

--- a/src/test/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.test.js
@@ -59,7 +59,6 @@ describe('<EditPortfolioItem />', () => {
     apiClientMock.patch(`${CATALOG_API_BASE}/portfolio_items/123`, mockOnce((req, res) => {
       expect(JSON.parse(req.body())).toEqual({
         name: 'foo',
-        id: '123',
         workflow_ref: '123',
         documentation_url: 'https://www.google.com/',
         support_url: 'https://www.google.com/',


### PR DESCRIPTION
### Fixes
- fixed unpermitted parameters in edit portfolio item payload
  - params `id, service_offering_source_ref, portfolio_id` are removed from object before calling the API