### PR TITLE
Sanitize patch requests based on openApi schema

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,9 +23,13 @@ import { CATALOG_API_BASE } from './utilities/constants';
 
 smoothscroll.polyfill();
 
+/**
+ * has to be in global context because nav listener is not a part of component lifecycle
+ */
+let ignoreRedirect = true;
+
 const App = () => {
   const [ auth, setAuth ] = useState(false);
-  const [ ignoreRedirect, setIgnoreRedirect ] = useState(true);
   const schema = useSelector(({ openApiReducer }) => openApiReducer);
   const dispatch = useDispatch();
   const history = useHistory();
@@ -61,7 +65,7 @@ const App = () => {
         history.push(`/${event.navId}`);
       }
 
-      setIgnoreRedirect(false);
+      ignoreRedirect = false;
     });
 
     return () => unregister();

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,5 +1,4 @@
-import { Route, Switch, Redirect } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
 import React, { lazy, Suspense } from 'react';
 import some from 'lodash/some';
 import { AppPlaceholder } from './presentational-components/shared/loader-placeholders';
@@ -17,8 +16,8 @@ const paths = {
   orders: '/orders'
 };
 
-export const Routes = props => {
-  const path = props.childProps.location.pathname;
+export const Routes = () => {
+  const { pathname } = useLocation();
   return (
     <Suspense fallback={ <AppPlaceholder /> }>
       <Switch>
@@ -26,13 +25,8 @@ export const Routes = props => {
         <Route path={ paths.portfolios } component={ Portfolios }/>
         <Route path={ paths.platforms } component={ Platforms }/>
         <Route path={ paths.orders } component={ Orders }/>
-        { /* Finally, catch all unmatched routes */ }
-        <Route render={ () => (some(paths, p => p === path) ? null : <Redirect to={ paths.portfolios } />) } />
+        <Route render={ () => (some(paths, p => p === pathname) ? null : <Redirect to={ paths.portfolios } />) } />
       </Switch>
     </Suspense>
   );
-};
-
-Routes.propTypes = {
-  childProps: PropTypes.object
 };

--- a/src/helpers/portfolio/portfolio-helper.js
+++ b/src/helpers/portfolio/portfolio-helper.js
@@ -1,7 +1,6 @@
 import { getAxiosInstance, getPortfolioApi, getPortfolioItemApi } from '../shared/user-login';
 import { CATALOG_API_BASE } from '../../utilities/constants';
-import { PORTFOLIO_ITEM_NULLABLE, PORTFOLIO_NULLABLE } from '../../constants/nullable-attributes';
-import { udefinedToNull } from '../shared/helpers';
+import { sanitizeValues } from '../shared/helpers';
 import { defaultSettings } from '../shared/pagination';
 
 const axiosInstance = getAxiosInstance();
@@ -52,8 +51,8 @@ export async function addToPortfolio(portfolioId, items) {
   return Promise.all(items.map(item => request(item)));
 }
 
-export async function updatePortfolio(portfolioData) {
-  return await portfolioApi.updatePortfolio(portfolioData.id,  udefinedToNull(portfolioData, PORTFOLIO_NULLABLE));
+export async function updatePortfolio({ id, ...portfolioData }, store) {
+  return await portfolioApi.updatePortfolio(id,  sanitizeValues(portfolioData, 'Portfolio', store));
 }
 
 export async function removePortfolio(portfolioId) {
@@ -88,8 +87,8 @@ export function fetchProviderControlParameters(portfolioItemId) {
     }}));
 }
 
-export async function updatePortfolioItem({ id, service_offering_source_ref, portfolio_id, ...portfolioItem }) {
-  return await portfolioItemApi.updatePortfolioItem(id, udefinedToNull(portfolioItem, PORTFOLIO_ITEM_NULLABLE));
+export async function updatePortfolioItem({ id, ...portfolioItem }, store) {
+  return await portfolioItemApi.updatePortfolioItem(id, sanitizeValues(portfolioItem, 'PortfolioItem', store));
 }
 
 export function fetchPortfolioByName(name = '') {

--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -1,4 +1,7 @@
 import moment from 'moment';
+import get from 'lodash/get';
+
+import { PORTFOLIO_ITEM_NULLABLE, PORTFOLIO_NULLABLE } from '../../constants/nullable-attributes';
 
 export const scrollToTop = () => document.getElementById('root').scrollTo({
   behavior: 'smooth',
@@ -44,3 +47,19 @@ export const udefinedToNull = (entity, keys) => [ ...Object.keys(entity), ...key
   ...acc,
   [curr]: entity[curr] === undefined ? null : entity[curr]
 }), {});
+
+const nullableMapper = {
+  PortfolioItem: PORTFOLIO_ITEM_NULLABLE,
+  Portfolio: PORTFOLIO_NULLABLE
+};
+
+export const sanitizeValues = (values, entityType, store) => {
+  const schemas = store.getState().openApiReducer.schema.components.schemas;
+  const permittedValues = Object.keys(values)
+  .filter(key => !get(schemas, `${entityType}.properties.${key}.readOnly`))
+  .reduce((acc, curr) => values[curr]
+    ? ({ ...acc, [curr]: values[curr] })
+    : acc,
+  {});
+  return udefinedToNull(permittedValues, nullableMapper[entityType]);
+};

--- a/src/redux/action-types.js
+++ b/src/redux/action-types.js
@@ -52,3 +52,8 @@ export const FETCH_ORDER_ITEMS = 'FETCH_ORDER_ITEMS';
  * Global redux loading state
  */
 export const SET_LOADING_STATE = 'SET_LOADING_STATE';
+
+/**
+ * OpenApi action
+ */
+export const SET_OPENAPI_SCHEMA = '@@open-api/set-schema';

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -84,16 +84,13 @@ export const addToPortfolio = (portfolioId, items) => ({
   }
 });
 
-export const updatePortfolio = portfolioData => dispatch => {
+export const updatePortfolio = portfolioData => (dispatch, getState) => {
   dispatch({
     type: ActionTypes.UPDATE_TEMPORARY_PORTFOLIO,
     payload: portfolioData
   });
 
-  return PortfolioHelper.updatePortfolio({
-    ...portfolioData,
-    workflow_ref: portfolioData.workflow_ref || null
-  })
+  return PortfolioHelper.updatePortfolio(portfolioData, { getState })
   .then(() => dispatch(doFetchPortfolios()))
   .then(() => dispatch({
     type: ADD_NOTIFICATION,
@@ -232,9 +229,9 @@ export const resetSelectedPortfolio = () => ({
   type: ActionTypes.RESET_SELECTED_PORTFOLIO
 });
 
-export const updatePortfolioItem = values => dispatch => {
+export const updatePortfolioItem = values => (dispatch, getState) => {
   dispatch({ type: ActionTypes.UPDATE_TEMPORARY_PORTFOLIO_ITEM, payload: values });
-  return PortfolioHelper.updatePortfolioItem(values)
+  return PortfolioHelper.updatePortfolioItem(values, { getState })
   .then(() => {
     dispatch({ type: ActionTypes.UPDATE_PORTFOLIO_ITEM, payload: values });
     return values;

--- a/src/redux/reducers/open-api-reducer.js
+++ b/src/redux/reducers/open-api-reducer.js
@@ -1,0 +1,10 @@
+import { SET_OPENAPI_SCHEMA } from '../action-types';
+
+export const openApiInitialState = {
+  schema: undefined
+};
+const setSchema = (state, { payload }) => ({ ...state, schema: payload });
+
+export default {
+  [SET_OPENAPI_SCHEMA]: setSchema
+};

--- a/src/test/__mocks__/open-api-mock.js
+++ b/src/test/__mocks__/open-api-mock.js
@@ -1,0 +1,18 @@
+export const openApiReducerMock = {
+  schema: {
+    components: {
+      schemas: {
+        Portfolio: {
+          properties: {}
+        },
+        PortfolioItem: {
+          properties: {
+            portfolio_id: {
+              readOnly: true
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -31,6 +31,8 @@ import {
   CATALOG_API_BASE
 } from '../../../utilities/constants';
 
+import { openApiReducerMock } from '../../__mocks__/open-api-mock';
+
 describe('Portfolio actions', () => {
   const middlewares = [ thunk, promiseMiddleware(), notificationsMiddleware() ];
   let mockStore;
@@ -181,7 +183,7 @@ describe('Portfolio actions', () => {
   });
 
   it('should create correct action creators when updating portfolio', () => {
-    const store = mockStore({});
+    const store = mockStore({ openApiReducer: openApiReducerMock });
     apiClientMock.get(`${CATALOG_API_BASE}/portfolios?filter%5Bname%5D%5Bcontains_i%5D=&limit=50&offset=0`,
       mockOnce({ body: [{ data: [], meta: {}}]}));
     apiClientMock.patch(CATALOG_API_BASE + '/portfolios/123', mockOnce({

--- a/src/test/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.test.js
@@ -11,6 +11,7 @@ import { MemoryRouter } from 'react-router-dom';
 import EditPortfolioItem from '../../../../smart-components/portfolio/portfolio-item-detail/edit-portfolio-item';
 import { CATALOG_API_BASE, APPROVAL_API_BASE } from '../../../../utilities/constants';
 import { UPDATE_TEMPORARY_PORTFOLIO_ITEM, UPDATE_PORTFOLIO_ITEM } from '../../../../redux/action-types';
+import { openApiReducerMock } from '../../../__mocks__/open-api-mock';
 
 describe('<EditPortfolioItem />', () => {
   const middlewares = [ thunk, promiseMiddleware(), notificationsMiddleware() ];
@@ -54,7 +55,8 @@ describe('<EditPortfolioItem />', () => {
 
   it('should submit form data', async done => {
     expect.assertions(3);
-    const store = mockStore({});
+    const store = mockStore({ openApiReducer: openApiReducerMock });
+    console.log(store.getState());
     apiClientMock.get(`${APPROVAL_API_BASE}/workflows`, mockOnce({ body: { data: []}}));
     apiClientMock.patch(`${CATALOG_API_BASE}/portfolio_items/123`, mockOnce((req, res) => {
       expect(JSON.parse(req.body())).toEqual({

--- a/src/test/utilities/store.test.js
+++ b/src/test/utilities/store.test.js
@@ -14,7 +14,8 @@ describe('redux store', () => {
       approvalReducer: expect.any(Object),
       rbacReducer: expect.any(Object),
       shareReducer: expect.any(Object),
-      notifications: expect.any(Object)
+      notifications: expect.any(Object),
+      openApiReducer: expect.any(Object)
     };
     expect(wrapper.props().store.getState()).toEqual(expectedState);
   });

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -11,6 +11,7 @@ import portfolioReducer, { portfoliosInitialState } from '../redux/reducers/port
 import approvalReducer, { approvalInitialState } from '../redux/reducers/approval-reducer';
 import rbacReducer, { rbacInitialState } from '../redux/reducers/rbac-reducer';
 import shareReducer, { shareInfoInitialState } from '../redux/reducers/share-reducer';
+import openApiReducer, { openApiInitialState } from '../redux/reducers/open-api-reducer';
 import loadingStateMiddleware from './loading-state-middleware';
 
 const registry = new ReducerRegistry({}, [ thunk, promiseMiddleware(), notificationsMiddleware({
@@ -33,6 +34,7 @@ registry.register({
   approvalReducer: applyReducerHash(approvalReducer, approvalInitialState),
   rbacReducer: applyReducerHash(rbacReducer, rbacInitialState),
   shareReducer: applyReducerHash(shareReducer, shareInfoInitialState),
+  openApiReducer: applyReducerHash(openApiReducer, openApiInitialState),
   notifications
 });
 


### PR DESCRIPTION
### Changes
- to avoid constant updates of unpermitted when updating catalog entities i added automatic cleanup based on openApi schema from `/api/catalog/v1.0/openapi.json` hosted in cloud services.

Related to: https://projects.engineering.redhat.com/browse/SSP-877 and many others. After this it should be automated.