### PR TITLE
Fixed minor prop types errors

### DIFF
--- a/src/presentational-components/portfolio/porfolio-card.js
+++ b/src/presentational-components/portfolio/porfolio-card.js
@@ -31,27 +31,21 @@ const createToolbarActions = (portfolioId, isOpen, setOpen) => [
     isPlain
     onSelect={ () => setOpen(false) }
     position={ DropdownPosition.right }
-    toggle={ <KebabToggle onToggle={ setOpen }/> }
+    toggle={ <KebabToggle onToggle={ isOpen => setOpen(isOpen) }/> }
     dropdownItems={ [
-      <DropdownItem key="share-portfolio-action" component={ Link } to={ `/portfolios/share/${portfolioId}` }>
-          Share
-      </DropdownItem>,
+      <DropdownItem key="share-portfolio-action" component={ <Link to={ `/portfolios/share/${portfolioId}` } >Share</Link> } />,
       <DropdownSeparator key="workflow-portfolio-separator"/>,
-      <DropdownItem key="workflow-portfolio-action" component={ Link } to={ `/portfolios/edit-workflow/${portfolioId}` }>
-          Edit approval
-      </DropdownItem>,
+      <DropdownItem
+        key="workflow-portfolio-action"
+        component={ <Link to={ `/portfolios/edit-workflow/${portfolioId}` }>Edit approval</Link> }
+      />,
       <DropdownSeparator key="share-portfolio-separator"/>,
-      <DropdownItem key="edit-portfolio-action" component={ Link } to={ `/portfolios/edit/${portfolioId}` }>
-          Edit
-      </DropdownItem>,
+      <DropdownItem key="edit-portfolio-action" component={ <Link to={ `/portfolios/edit/${portfolioId}` }>Edit</Link> }/>,
       <DropdownItem
         key="remove-portfolio-action"
-        component={ Link }
-        to={ `/portfolios/remove/${portfolioId}` }
         className="pf-c-dropdown__menu-item destructive-color"
-      >
-          Delete
-      </DropdownItem>
+        component={ <Link to={ `/portfolios/remove/${portfolioId}` }>Delete</Link> }
+      />
     ] }/>
 ];
 

--- a/src/presentational-components/shared/top-toolbar.js
+++ b/src/presentational-components/shared/top-toolbar.js
@@ -37,7 +37,7 @@ export const TopToolbarTitle = ({ title, children, ...rest }) => (
     <Level className="pf-u-mb-md" { ...rest }>
       <LevelItem>
         <TextContent className="top-toolbar-title">
-          { <Text component={ TextVariants.h2 }>{ title || <ToolbarTitlePlaceholder /> }</Text> }
+          { <Text component={ TextVariants.h2 }>{ title }</Text> }
         </TextContent>
       </LevelItem>
       { children }
@@ -46,9 +46,13 @@ export const TopToolbarTitle = ({ title, children, ...rest }) => (
 );
 
 TopToolbarTitle.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)
   ])
+};
+
+TopToolbarTitle.defaultProps = {
+  title: <ToolbarTitlePlaceholder />
 };

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -18,20 +18,18 @@ const DetailToolbarActions = ({ copyUrl, orderUrl, editUrl, workflowUrl, isOpen,
           onToggle={ setOpen }
           onSelect={ () => setOpen(false) }
           position={ DropdownPosition.right }
-          toggle={ <KebabToggle onToggle={ setOpen }/> }
+          toggle={ <KebabToggle onToggle={ isOpen => setOpen(isOpen) }/> }
           isOpen={ isOpen }
           dropdownItems={ [
-            <DropdownItem aria-label="Edit Portfolio" key="edit-portfolio" component={ Link } to={ editUrl } role="link">
-                Edit
-            </DropdownItem>,
-            <DropdownItem aria-label="Copy Portfolio" key="copy-portfolio" component={ Link } to={ copyUrl } role="link">
-                Copy
-            </DropdownItem>,
+            <DropdownItem aria-label="Edit Portfolio" key="edit-portfolio" component={ <Link to={ editUrl }>Edit</Link> } role="link"/>,
+            <DropdownItem aria-label="Copy Portfolio" key="copy-portfolio" component={ <Link to={ copyUrl }>Copy</Link> } role="link"/>,
             <DropdownSeparator key="workflow-portfolio-separator"/>,
-            <DropdownItem aria-label="Edit Approval Workflow" key="edit-approval_workflow" component = { Link }
-              to={ workflowUrl } role="link" >
-                Edit approval
-            </DropdownItem>
+            <DropdownItem
+              aria-label="Edit Approval Workflow"
+              key="edit-approval_workflow"
+              component={ <Link to={ workflowUrl }>Edit approval</Link> }
+              role="link"
+            />
           ] }
         />
       </LevelItem>

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -73,7 +73,7 @@ const PortfolioItems = ({
 );
 
 PortfolioItems.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   filteredItems: PropTypes.shape({ items: PropTypes.arrayOf(PropTypes.node), isLoading: PropTypes.bool }),
   portfolioRoute: PropTypes.string.isRequired,
   addProductsRoute: PropTypes.string.isRequired,

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
@@ -17,83 +17,43 @@ exports[`<PortfolioCard /> should render correctly 1`] = `
                   Array [
                     <DropdownItem
                       component={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "displayName": "Link",
-                          "propTypes": Object {
-                            "innerRef": [Function],
-                            "onClick": [Function],
-                            "replace": [Function],
-                            "target": [Function],
-                            "to": [Function],
-                          },
-                          "render": [Function],
-                        }
+                        <ForwardRef
+                          to="/portfolios/share/123"
+                        >
+                          Share
+                        </ForwardRef>
                       }
-                      to="/portfolios/share/123"
-                    >
-                      Share
-                    </DropdownItem>,
+                    />,
                     <DropdownSeparator />,
                     <DropdownItem
                       component={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "displayName": "Link",
-                          "propTypes": Object {
-                            "innerRef": [Function],
-                            "onClick": [Function],
-                            "replace": [Function],
-                            "target": [Function],
-                            "to": [Function],
-                          },
-                          "render": [Function],
-                        }
+                        <ForwardRef
+                          to="/portfolios/edit-workflow/123"
+                        >
+                          Edit approval
+                        </ForwardRef>
                       }
-                      to="/portfolios/edit-workflow/123"
-                    >
-                      Edit approval
-                    </DropdownItem>,
+                    />,
                     <DropdownSeparator />,
                     <DropdownItem
                       component={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "displayName": "Link",
-                          "propTypes": Object {
-                            "innerRef": [Function],
-                            "onClick": [Function],
-                            "replace": [Function],
-                            "target": [Function],
-                            "to": [Function],
-                          },
-                          "render": [Function],
-                        }
+                        <ForwardRef
+                          to="/portfolios/edit/123"
+                        >
+                          Edit
+                        </ForwardRef>
                       }
-                      to="/portfolios/edit/123"
-                    >
-                      Edit
-                    </DropdownItem>,
+                    />,
                     <DropdownItem
                       className="pf-c-dropdown__menu-item destructive-color"
                       component={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "displayName": "Link",
-                          "propTypes": Object {
-                            "innerRef": [Function],
-                            "onClick": [Function],
-                            "replace": [Function],
-                            "target": [Function],
-                            "to": [Function],
-                          },
-                          "render": [Function],
-                        }
+                        <ForwardRef
+                          to="/portfolios/remove/123"
+                        >
+                          Delete
+                        </ForwardRef>
                       }
-                      to="/portfolios/remove/123"
-                    >
-                      Delete
-                    </DropdownItem>,
+                    />,
                   ]
                 }
                 isOpen={false}

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -104,66 +104,35 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
             <DropdownItem
               aria-label="Edit Portfolio"
               component={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "Link",
-                  "propTypes": Object {
-                    "innerRef": [Function],
-                    "onClick": [Function],
-                    "replace": [Function],
-                    "target": [Function],
-                    "to": [Function],
-                  },
-                  "render": [Function],
-                }
+                <ForwardRef
+                  to="foo/baz"
+                >
+                  Edit
+                </ForwardRef>
               }
               role="link"
-              to="foo/baz"
-            >
-              Edit
-            </DropdownItem>,
+            />,
             <DropdownItem
               aria-label="Copy Portfolio"
               component={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "Link",
-                  "propTypes": Object {
-                    "innerRef": [Function],
-                    "onClick": [Function],
-                    "replace": [Function],
-                    "target": [Function],
-                    "to": [Function],
-                  },
-                  "render": [Function],
-                }
+                <ForwardRef
+                  to="foo/copy"
+                >
+                  Copy
+                </ForwardRef>
               }
               role="link"
-              to="foo/copy"
-            >
-              Copy
-            </DropdownItem>,
+            />,
             <DropdownSeparator />,
             <DropdownItem
               aria-label="Edit Approval Workflow"
               component={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "Link",
-                  "propTypes": Object {
-                    "innerRef": [Function],
-                    "onClick": [Function],
-                    "replace": [Function],
-                    "target": [Function],
-                    "to": [Function],
-                  },
-                  "render": [Function],
-                }
+                <ForwardRef>
+                  Edit approval
+                </ForwardRef>
               }
               role="link"
-            >
-              Edit approval
-            </DropdownItem>,
+            />,
           ]
         }
         isOpen={false}
@@ -173,7 +142,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
         position="right"
         toggle={
           <KebabToggle
-            onToggle={[MockFunction]}
+            onToggle={[Function]}
           />
         }
       >
@@ -183,66 +152,35 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
               <DropdownItem
                 aria-label="Edit Portfolio"
                 component={
-                  Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "displayName": "Link",
-                    "propTypes": Object {
-                      "innerRef": [Function],
-                      "onClick": [Function],
-                      "replace": [Function],
-                      "target": [Function],
-                      "to": [Function],
-                    },
-                    "render": [Function],
-                  }
+                  <ForwardRef
+                    to="foo/baz"
+                  >
+                    Edit
+                  </ForwardRef>
                 }
                 role="link"
-                to="foo/baz"
-              >
-                Edit
-              </DropdownItem>,
+              />,
               <DropdownItem
                 aria-label="Copy Portfolio"
                 component={
-                  Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "displayName": "Link",
-                    "propTypes": Object {
-                      "innerRef": [Function],
-                      "onClick": [Function],
-                      "replace": [Function],
-                      "target": [Function],
-                      "to": [Function],
-                    },
-                    "render": [Function],
-                  }
+                  <ForwardRef
+                    to="foo/copy"
+                  >
+                    Copy
+                  </ForwardRef>
                 }
                 role="link"
-                to="foo/copy"
-              >
-                Copy
-              </DropdownItem>,
+              />,
               <DropdownSeparator />,
               <DropdownItem
                 aria-label="Edit Approval Workflow"
                 component={
-                  Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "displayName": "Link",
-                    "propTypes": Object {
-                      "innerRef": [Function],
-                      "onClick": [Function],
-                      "replace": [Function],
-                      "target": [Function],
-                      "to": [Function],
-                    },
-                    "render": [Function],
-                  }
+                  <ForwardRef>
+                    Edit approval
+                  </ForwardRef>
                 }
                 role="link"
-              >
-                Edit approval
-              </DropdownItem>,
+              />,
             ]
           }
           isOpen={false}
@@ -251,7 +189,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
           position="right"
           toggle={
             <KebabToggle
-              onToggle={[MockFunction]}
+              onToggle={[Function]}
             />
           }
         >
@@ -263,73 +201,42 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                   <DropdownItem
                     aria-label="Edit Portfolio"
                     component={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "displayName": "Link",
-                        "propTypes": Object {
-                          "innerRef": [Function],
-                          "onClick": [Function],
-                          "replace": [Function],
-                          "target": [Function],
-                          "to": [Function],
-                        },
-                        "render": [Function],
-                      }
+                      <ForwardRef
+                        to="foo/baz"
+                      >
+                        Edit
+                      </ForwardRef>
                     }
                     role="link"
-                    to="foo/baz"
-                  >
-                    Edit
-                  </DropdownItem>,
+                  />,
                   <DropdownItem
                     aria-label="Copy Portfolio"
                     component={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "displayName": "Link",
-                        "propTypes": Object {
-                          "innerRef": [Function],
-                          "onClick": [Function],
-                          "replace": [Function],
-                          "target": [Function],
-                          "to": [Function],
-                        },
-                        "render": [Function],
-                      }
+                      <ForwardRef
+                        to="foo/copy"
+                      >
+                        Copy
+                      </ForwardRef>
                     }
                     role="link"
-                    to="foo/copy"
-                  >
-                    Copy
-                  </DropdownItem>,
+                  />,
                   <DropdownSeparator />,
                   <DropdownItem
                     aria-label="Edit Approval Workflow"
                     component={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "displayName": "Link",
-                        "propTypes": Object {
-                          "innerRef": [Function],
-                          "onClick": [Function],
-                          "replace": [Function],
-                          "target": [Function],
-                          "to": [Function],
-                        },
-                        "render": [Function],
-                      }
+                      <ForwardRef>
+                        Edit approval
+                      </ForwardRef>
                     }
                     role="link"
-                  >
-                    Edit approval
-                  </DropdownItem>,
+                  />,
                 ],
                 "isOpen": false,
                 "isPlain": true,
                 "onToggle": [MockFunction],
                 "position": "right",
                 "toggle": <KebabToggle
-                  onToggle={[MockFunction]}
+                  onToggle={[Function]}
                 />,
               }
             }
@@ -344,66 +251,35 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                   <DropdownItem
                     aria-label="Edit Portfolio"
                     component={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "displayName": "Link",
-                        "propTypes": Object {
-                          "innerRef": [Function],
-                          "onClick": [Function],
-                          "replace": [Function],
-                          "target": [Function],
-                          "to": [Function],
-                        },
-                        "render": [Function],
-                      }
+                      <ForwardRef
+                        to="foo/baz"
+                      >
+                        Edit
+                      </ForwardRef>
                     }
                     role="link"
-                    to="foo/baz"
-                  >
-                    Edit
-                  </DropdownItem>,
+                  />,
                   <DropdownItem
                     aria-label="Copy Portfolio"
                     component={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "displayName": "Link",
-                        "propTypes": Object {
-                          "innerRef": [Function],
-                          "onClick": [Function],
-                          "replace": [Function],
-                          "target": [Function],
-                          "to": [Function],
-                        },
-                        "render": [Function],
-                      }
+                      <ForwardRef
+                        to="foo/copy"
+                      >
+                        Copy
+                      </ForwardRef>
                     }
                     role="link"
-                    to="foo/copy"
-                  >
-                    Copy
-                  </DropdownItem>,
+                  />,
                   <DropdownSeparator />,
                   <DropdownItem
                     aria-label="Edit Approval Workflow"
                     component={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "displayName": "Link",
-                        "propTypes": Object {
-                          "innerRef": [Function],
-                          "onClick": [Function],
-                          "replace": [Function],
-                          "target": [Function],
-                          "to": [Function],
-                        },
-                        "render": [Function],
-                      }
+                      <ForwardRef>
+                        Edit approval
+                      </ForwardRef>
                     }
                     role="link"
-                  >
-                    Edit approval
-                  </DropdownItem>,
+                  />,
                 ]
               }
               isGrouped={false}
@@ -421,7 +297,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
               position="right"
               toggle={
                 <KebabToggle
-                  onToggle={[MockFunction]}
+                  onToggle={[Function]}
                 />
               }
             >
@@ -436,7 +312,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                   isPlain={true}
                   key=".0"
                   onEnter={[Function]}
-                  onToggle={[MockFunction]}
+                  onToggle={[Function]}
                   parentRef={
                     Object {
                       "current": <div
@@ -483,7 +359,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     isPrimary={false}
                     isSplitButton={false}
                     onEnter={[Function]}
-                    onToggle={[MockFunction]}
+                    onToggle={[Function]}
                     parentRef={
                       Object {
                         "current": <div

--- a/src/toolbar/schemas/portfolio-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolio-toolbar.schema.js
@@ -23,23 +23,25 @@ const PortfolioActionsToolbar = ({ editPortfolioRoute, workflowPortfolioRoute, r
         <DropdownItem component="button" aria-label="Copy Portfolio" key="copy-portfolio" onClick={ copyPortfolio }>
         Copy
         </DropdownItem>,
-        <DropdownItem aria-label="Edit Approval Workflow" key="edit-approval_workflow" component = { Link }
-          to={ workflowPortfolioRoute } role="link" >
-          Edit approval
-        </DropdownItem>,
-        <DropdownItem aria-label="Edit Portfolio" key="edit-portfolio" component={ Link } to={ editPortfolioRoute } role="link">
-            Edit
-        </DropdownItem>,
+        <DropdownItem
+          aria-label="Edit Approval Workflow"
+          key="edit-approval_workflow"
+          component={ <Link to={ workflowPortfolioRoute }>Edit approval</Link> }
+          role="link"
+        />,
+        <DropdownItem
+          aria-label="Edit Portfolio"
+          key="edit-portfolio"
+          component={ <Link to={ editPortfolioRoute }>Edit</Link> }
+          role="link"
+        />,
         <DropdownItem
           aria-label="Remove Portfolio"
           key="delete-portfolio"
-          component={ Link }
-          to={ removePortfolioRoute }
+          component={ <Link to={ removePortfolioRoute }>Delete</Link> }
           role="link"
           className="pf-c-dropdown__menu-item destructive-color"
-        >
-          Delete
-        </DropdownItem>
+        />
       ] }
     />
   );};


### PR DESCRIPTION
### Changes
- use different component passing to PF dropdown item
  - their type checking only allows ReactNode instead of any render able node
- removed `isRequired` from top toolbar prop type checking
- use default prop for top toolbar title instead of checking it in each render cycle