### PR TITLE
Fix for Add/Edit portfolio modal 

### DIFF
--- a/src/smart-components/portfolio/add-portfolio-modal.tsx
+++ b/src/smart-components/portfolio/add-portfolio-modal.tsx
@@ -113,8 +113,7 @@ const AddPortfolioModal: React.ComponentType<AddPortfolioModalProps> = ({
           : (formatMessage(portfolioMessages.modalCreateTitle) as string),
         isOpen,
         onClose: () => push(closeTarget),
-        variant: 'small',
-        isLoading: !!(!portfolioId || editVariant)
+        variant: 'small'
       }}
       templateProps={{
         submitLabel: portfolioId


### PR DESCRIPTION
Remove the isLoading flag from the the add/edit portfolio schema. ( not used and incorrectly set to true for both add and edit and causing the Form renderer to always display the spinning loading circle rather than the form).

Fixes https://issues.redhat.com/browse/SSP-2465