### PR TITLE
Update Axios to v0.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@redhat-cloud-services/rbac-client": "^1.0.93",
     "@types/react-truncate": "^2.3.4",
     "awesome-debounce-promise": "^2.1.0",
-    "axios": "^0.21.1",
+    "axios": "^0.25.0",
     "classnames": "^2.2.6",
     "clsx": "^1.0.4",
     "detect-browser": "^5.2.0",


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2682

The 'follow-redirects' package is a dependency that axios relies upon, and thus they released v0.25.0 to update follow-redirects to a version with a fix for the above security flaw. https://github.com/axios/axios/releases/tag/v0.25.0